### PR TITLE
Tests to capture reverse encoding of little and big endians added

### DIFF
--- a/raaz-primitives/tests/Modules/Types.hs
+++ b/raaz-primitives/tests/Modules/Types.hs
@@ -3,8 +3,11 @@
 
 module Modules.Types where
 
+import qualified Data.ByteString as BS
 import Data.Word
 import Test.QuickCheck
+import Test.Framework
+import Test.Framework.Providers.QuickCheck2 (testProperty)
 
 import Raaz.Types
 import Raaz.Test.CryptoStore
@@ -22,8 +25,28 @@ instance Arbitrary Word64LE where
 instance Arbitrary Word64BE where
   arbitrary = fmap fromIntegral (arbitrary :: Gen Word64)
 
+-- | This test captures the property that bytestring encodings of Little
+-- Endian word is same as reversing the bytestring encoding of Big endian word.
+prop_LEBEreverse32 :: Word32 -> Bool
+prop_LEBEreverse32 w = toByteString wle == BS.reverse (toByteString wbe )
+       where wle = (fromIntegral w) :: Word32LE
+             wbe = (fromIntegral w) :: Word32BE
+
+testLEBEreverse32 :: Test
+testLEBEreverse32 = testProperty "ReverseLEBE32" prop_LEBEreverse32
+
+prop_LEBEreverse64 :: Word64 -> Bool
+prop_LEBEreverse64 w = toByteString wle == BS.reverse (toByteString wbe )
+       where wle = (fromIntegral w) :: Word64LE
+             wbe = (fromIntegral w) :: Word64BE
+
+testLEBEreverse64 :: Test
+testLEBEreverse64 = testProperty "ReverseLEBE64" prop_LEBEreverse64
+
 tests = [ testStoreLoad (undefined :: Word32LE)
         , testStoreLoad (undefined :: Word32BE)
         , testStoreLoad (undefined :: Word64LE)
         , testStoreLoad (undefined :: Word64BE)
+        , testLEBEreverse32
+        , testLEBEreverse64
         ]


### PR DESCRIPTION
There are some problems to capture the dual of a type like 
dual of Word32LE = Word32BE
and allowing conversion from one to other.

Since we can not export the constructors from the original types module I have used unsafeCoerce to change the types. As the internal representation of both of them is Word32 so it does not matter, but think of some other way of integrating this in the test case without exporting the constructors.
One way would be to write test case for all of them separately or capture the dual relationship in a type class or a type family. 
I have used the type family approach. Look into it and let me know if there are any problems. 

-Satvik 
