### PR TITLE
Utility on gadgets to abstract out application on bytesource without padding

### DIFF
--- a/raaz-primitives/Raaz/Util/Gadget.hs
+++ b/raaz-primitives/Raaz/Util/Gadget.hs
@@ -1,0 +1,28 @@
+{-
+
+This module contains some abstractions built on top of gadgets
+
+-}
+
+module Raaz.Util.Gadget ( applyOnByteSource )where
+
+import Raaz.ByteSource
+import Raaz.Primitives
+import Raaz.Types
+import Raaz.Util.Ptr
+
+-- | Apply the given gadget on the bytesource. This function is
+-- different from transformGadget as it assumes that number of bytes
+-- in the source is in the multiple of block size of the primitive.
+applyOnByteSource :: ( ByteSource src
+                     , Gadget g )
+                     => g     -- ^ Gadget
+                     -> src   -- ^ The byte source
+                     -> IO ()
+applyOnByteSource g src = allocaBuffer nBlocks $ go src
+  where nBlocks = recommendedBlocks g
+        go source cptr =   fill nBlocks source cptr
+                             >>= withFillResult continue endIt
+           where continue rest = do apply g nBlocks cptr
+                                    go rest cptr
+                 endIt r       = apply g (cryptoCoerce r) cptr

--- a/raaz-primitives/raaz-primitives.cabal
+++ b/raaz-primitives/raaz-primitives.cabal
@@ -26,6 +26,7 @@ library
                  , Raaz.System.Parameters
                  , Raaz.Types
                  , Raaz.Util.ByteString
+                 , Raaz.Util.Gadget
                  , Raaz.Util.Ptr
                  , Raaz.Util.SecureMemory
                  , Raaz.Util.TH


### PR DESCRIPTION
This will abstract out some common code from raaz-tests and raaz-benchmarks
