### PR TITLE
Unsafe CryptoCoerce instances removed

### DIFF
--- a/raaz-core/Raaz/Primitives.hs
+++ b/raaz-core/Raaz/Primitives.hs
@@ -338,28 +338,6 @@ instance ( Primitive p
                prim _ = undefined
   {-# INLINE cryptoCoerce #-}
 
--- | BEWARE: There can be rounding errors if the number of bytes is
--- not a multiple of block length.
-instance ( Primitive p
-         , Integral by
-         ) => CryptoCoerce (BYTES by) (BLOCKS p) where
-  cryptoCoerce bytes = result
-         where prim :: BLOCKS p -> p
-               prim _ = undefined
-               result = BLOCKS (fromIntegral m)
-               m      = fromIntegral bytes `quot` blockSize (prim result)
-  {-# INLINE cryptoCoerce #-}
-
--- | BEWARE: There can be rounding errors if the number of bytes is
--- not a multiple of block length.
-instance ( Primitive p
-         , Integral by
-         ) => CryptoCoerce (BITS by) (BLOCKS p) where
-  cryptoCoerce = cryptoCoerce . bytes
-    where bytes :: Integral by => BITS by -> BYTES by
-          bytes = cryptoCoerce
-  {-# INLINE cryptoCoerce #-}
-
 
 instance ( Primitive p
          , Num by

--- a/raaz-core/Raaz/Types.hs
+++ b/raaz-core/Raaz/Types.hs
@@ -293,16 +293,6 @@ instance ( Integral by
   cryptoCoerce by = 8 * fromIntegral by
   {-# INLINE cryptoCoerce #-}
 
--- | BEWARE: If the number of bits is not an integral multiple of 8
--- then there are rounding errors.
-instance ( Integral bi
-         , Real bi
-         , Num by
-         )
-         => CryptoCoerce (BITS bi) (BYTES by) where
-  cryptoCoerce bi = fromIntegral $ quot bi 8
-  {-# INLINE cryptoCoerce #-}
-
 instance ( Integral by1
          , Num by2
          ) => CryptoCoerce (BYTES by1) (BYTES by2) where

--- a/raaz-core/Raaz/Util/SecureMemory.hs
+++ b/raaz-core/Raaz/Util/SecureMemory.hs
@@ -196,13 +196,6 @@ newtype PAGES a = PAGES a deriving ( Show, Enum, Real
                                    , Integral, Num, Eq, Ord
                                    )
 
-instance ( Integral by
-         , Num pg
-         )
-         => CryptoCoerce (BYTES by) (PAGES pg) where
-  cryptoCoerce by | r == 0    = fromIntegral q
-                  | otherwise = fromIntegral q + 1
-    where (q,r) = fromIntegral by `quotRem` pageSize
 
 instance ( Integral pg
          , Num by


### PR DESCRIPTION
This was not removed in the pull request for adding the new `Rounding` class and it's instances.
