### PR TITLE
modules for general pointer gymnastics

### DIFF
--- a/raaz-core/Raaz/Core/Gymnastics.hs
+++ b/raaz-core/Raaz/Core/Gymnastics.hs
@@ -2,11 +2,11 @@
 -- gymnastics. This module provide a framework to perform some of them
 -- cleanly and safely. One can use
 
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 {-# LANGUAGE FlexibleInstances          #-}
 module Raaz.Core.Gymnastics
        ( Manoeuvre(..)
-       , manoeuvre
+       , manoeuvre, manoeuvre'
        -- * Applicative parsing manoeuvre
 
        -- * Monoidal Writing Manoeuvre
@@ -55,3 +55,8 @@ manoeuvre :: LengthUnit l => Manoeuvre l IO a -> CryptoBuffer -> IO (Maybe a)
 manoeuvre mA cbuf = withCryptoBuffer cbuf $ \ sz cptr ->
   if sz < inBytes (sizeAffected mA) then pure Nothing
   else Just <$> unsafeManoeuvre mA cptr
+
+manoeuvre' :: LengthUnit l => Manoeuvre l IO a -> CryptoBuffer -> IO a
+manoeuvre' mA cbuf  = withCryptoBuffer cbuf $ \ sz cptr ->
+  if sz < inBytes (sizeAffected mA) then fail "manoeuvre': not enough space in the buffer"
+  else unsafeManoeuvre mA cptr

--- a/raaz-core/Raaz/Core/Gymnastics.hs
+++ b/raaz-core/Raaz/Core/Gymnastics.hs
@@ -1,0 +1,57 @@
+-- | Processing data in buffers involve a lot of pointer
+-- gymnastics. This module provide a framework to perform some of them
+-- cleanly and safely. One can use
+
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleInstances          #-}
+module Raaz.Core.Gymnastics
+       ( Manoeuvre(..)
+       , manoeuvre
+       -- * Applicative parsing manoeuvre
+
+       -- * Monoidal Writing Manoeuvre
+       ) where
+import Control.Applicative
+import Data.Monoid
+
+import Raaz.Core.Types
+import Raaz.Core.Util.Ptr (movePtr)
+
+-- | The type @Manoeuvre l m a@ is a gymnastic manoeuvre involving a
+-- pointer.  As the name suggests a gymnastic is tricky and dangerous
+-- and should be done with care. However, Haskell types make it easy
+-- to keep things safe. The parameter @m@ is typically a monad (mostly
+-- IO) which corresponds to the action taken. Each manoeuvre affects
+-- certain bytes at the location where it is applied. The type
+-- argument @l@ is a length units in which we measure the amount of
+-- data effected.
+data Manoeuvre l m a =
+  Manoeuvre { sizeAffected :: !l
+                              -- ^ The size of data that is affected by this
+                              -- gymnastic manoeuvre.
+            , unsafeManoeuvre :: CryptoPtr -> m a
+                              -- The actual pointer gymnastic.
+            }
+
+instance Functor m => Functor (Manoeuvre l m) where
+  fmap f (Manoeuvre l act) = Manoeuvre l $ (\ cptr -> fmap f $ act cptr)
+
+instance (LengthUnit l, Applicative m) => Applicative (Manoeuvre l m) where
+  pure = Manoeuvre 0 . const . pure
+  (<*>) mf ma = Manoeuvre faSize mfa
+    where mfa = \ fptr -> unsafeManoeuvre mf fptr <*> unsafeManoeuvre ma (fptr `movePtr` fSize)
+          fSize    = sizeAffected mf
+          aSize    = sizeAffected ma
+          faSize   = fSize + aSize
+
+-- | When the return value of the action is not relevant Manoeuvres are monoids as well.
+instance (LengthUnit l, Applicative m) => Monoid (Manoeuvre l m ()) where
+  mempty = pure ()
+  mappend m1 m2 = m1 <* m2
+  mconcat = foldl mempty *> mempty
+
+-- | Run a manoeuvre on a cryptobuffer.
+manoeuvre :: LengthUnit l => Manoeuvre l IO a -> CryptoBuffer -> IO (Maybe a)
+manoeuvre mA cbuf = withCryptoBuffer cbuf $ \ sz cptr ->
+  if sz < inBytes (sizeAffected mA) then pure Nothing
+  else Just <$> unsafeManoeuvre mA cptr

--- a/raaz-core/Raaz/Core/Parse/Applicative.hs
+++ b/raaz-core/Raaz/Core/Parse/Applicative.hs
@@ -1,6 +1,6 @@
 -- | An applicative version of parser. This provides a restricted
 -- parser which has only an applicative instance.
-
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Raaz.Core.Parse.Applicative
        ( Parser, parseWidth
        , runParser, runParser', unsafeRunParser
@@ -8,67 +8,38 @@ module Raaz.Core.Parse.Applicative
        , parseByteString
        ) where
 
-import           Control.Applicative
+import           Control.Applicative       (Applicative)
 import           Data.ByteString           (ByteString)
 import           Foreign.Ptr               (castPtr)
 import           Foreign.Storable          (Storable, peek)
 
+import           Raaz.Core.Gymnastics
 import           Raaz.Core.Types
 import           Raaz.Core.Util.ByteString (createFrom)
-import           Raaz.Core.Util.Ptr        (byteSize, movePtr)
--- | The parser.
-data Parser a =
-  Parser { parseWidth  :: !(BYTES Int) -- ^ How many characters the
-                          -- parser will consume.
-         , parseAction :: CryptoPtr -> IO a
-                          -- ^ The IO action that needs to be run to
-                          -- obtain a.
-         }
+import           Raaz.Core.Util.Ptr        (byteSize)
 
+-- | An applicative parser type for reading data from a pointer.
+newtype Parser a = Parser { unParser :: Manoeuvre (BYTES Int) IO a }
+                 deriving (Functor, Applicative)
 
--- | Runs a given parser on a cryptographic buffer. If the buffer is not
--- big enough, it will return `Nothing`.
-runParser :: Parser a     -- ^ the parser to run.
-          -> CryptoBuffer -- ^ the buffer on which to run the parser.
-          -> IO (Maybe a)
-runParser pA cbuf = withCryptoBuffer cbuf $ \ sz cptr ->
-  if sz < parseWidth pA then return Nothing
-  else Just <$> unsafeRunParser pA cptr
+makeParser :: LengthUnit l => l -> (CryptoPtr -> IO a) -> Parser a
+makeParser l action = Parser $ Manoeuvre (inBytes l) action
 
--- | Similar to `runParser` but raises an error if the buffer is not
--- big enough.
-runParser' :: Parser a     -- ^ the parser to run.
-           -> CryptoBuffer -- ^ the buffer on which to run the parser.
-           -> IO a
-runParser' pA cbuf = withCryptoBuffer cbuf $ \ sz cptr ->
-  if sz < parseWidth pA then fail "parse error: buffer not big enough"
-  else unsafeRunParser pA cptr
+-- | Return the bytes that this parser will read.
+parseWidth :: Parser a -> BYTES Int
+parseWidth = sizeAffected . unParser
 
--- | Runs the applicative parser on a crypto pointer. This is highly
--- unsafe because as no checks is (can be) done on the input pointer
--- to make sure that there is enough data there. Useful in the
--- declaration of Endian store.
+-- | Run the given parser.
+runParser :: Parser a -> CryptoBuffer -> IO (Maybe a)
+runParser = manoeuvre . unParser
+
+-- | Run the parser given the
+runParser' :: Parser a -> CryptoBuffer -> IO a
+runParser' = manoeuvre' . unParser
+
+-- | Run the parser without checking the length constraints.
 unsafeRunParser :: Parser a -> CryptoPtr -> IO a
-unsafeRunParser = parseAction
-
-instance Functor Parser where
-  fmap f pA = Parser { parseWidth  = parseWidth pA
-                     , parseAction = fmap f . parseAction pA
-                     }
-
-instance Applicative Parser where
-    pure = Parser 0 . const . return
-
-    (<*>) pF pX = Parser { parseWidth  = wF + wX
-                         , parseAction = action
-                         }
-      where wF = parseWidth pF -- width of parsing f
-            wX = parseWidth pX -- width of parsing X
-            action startF =   parseAction pF startF
-                          <*> parseAction pX endF
-                          -- X starts from where F ends
-              where endF = startF `movePtr` wF
-
+unsafeRunParser = unsafeManoeuvre . unParser
 
 -- | The primary purpose of this function is to satisfy type checkers.
 undefParse :: Parser a -> a
@@ -80,9 +51,7 @@ undefParse _ = undefined
 -- `Storable` instance.
 parseStorable :: Storable a => Parser a
 parseStorable = pa
-  where pa = Parser { parseWidth  = byteSize $ undefParse pa
-                    , parseAction = peek . castPtr
-                    }
+  where pa = makeParser (byteSize $ undefParse pa) (peek . castPtr)
 
 -- | Parse a crypto value. Endian safety is take into account
 -- here. This is what you would need when you parse packets from an
@@ -90,10 +59,8 @@ parseStorable = pa
 -- function in a complicated `EndianStore` instance.
 parse :: EndianStore a => Parser a
 parse = pa
-  where pa = Parser { parseWidth  = byteSize $ undefParse pa
-                    , parseAction = load
-                    }
+  where pa = makeParser (byteSize $ undefParse pa) load
 
 -- | Parses a strict bytestring of a given length.
 parseByteString :: LengthUnit l => l -> Parser ByteString
-parseByteString l = Parser (inBytes l) $ createFrom l
+parseByteString l = makeParser l $ createFrom l

--- a/raaz-core/Raaz/Core/Write.hs
+++ b/raaz-core/Raaz/Core/Write.hs
@@ -5,24 +5,25 @@
 
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
+
 
 module Raaz.Core.Write
-       ( Write, tryWriting
+       ( Write, bytesToWrite, tryWriting
        , write, writeStorable
        , writeBytes, writeByteString
        ) where
 
+import           Control.Applicative
 import           Data.ByteString           (ByteString)
 import           Data.Monoid
 import           Data.Word                 (Word8)
+import           Foreign.Ptr               (castPtr)
 import           Foreign.Storable
 
+import           Raaz.Core.Gymnastics
 import           Raaz.Core.Types
 import           Raaz.Core.Util.ByteString as BU
 import           Raaz.Core.Util.Ptr
-
-import qualified Raaz.Core.Write.Unsafe    as WU
 
 -- | A write is an action which when executed using `runWrite` writes
 -- bytes to the input buffer. It is similar to the `WU.Write` type
@@ -31,8 +32,27 @@ import qualified Raaz.Core.Write.Unsafe    as WU
 -- action is run. The `runWrite` action will raise an error if the
 -- buffer it is provided with is of size smaller. `Write`s are monoid
 -- and hence can be concatnated using the `<>` operator.
-newtype Write = Write (Sum (BYTES Int), WU.Write)
+newtype Write = Write { unWrite :: Manoeuvre (BYTES Int) IO () }
               deriving Monoid
+
+-- | Create a write action.
+makeWrite :: BYTES Int -> (CryptoPtr -> IO ()) -> Write
+makeWrite sz = Write . Manoeuvre sz
+
+-- | Returns the bytes that will be written when the write action is performed.
+bytesToWrite :: Write -> BYTES Int
+bytesToWrite = sizeAffected . unWrite
+
+
+-- | The function tries to write the given `Write` action on the
+-- buffer and returns `True` if successful.
+tryWriting :: Write         -- ^ The write action.
+           -> CryptoBuffer  -- ^ The buffer to which the bytes are to
+                            -- be written.
+           -> IO Bool
+tryWriting wr cbuf = toBool <$> manoeuvre (unWrite wr) cbuf
+  where toBool = maybe False (const True)
+
 
 -- | The expression @`writeStorable` a@ gives a write action that
 -- stores a value @a@ in machine endian. The type of the value @a@ has
@@ -41,52 +61,22 @@ newtype Write = Write (Sum (BYTES Int), WU.Write)
 -- (otherwise this could lead to endian confusion). To take care of
 -- endianness use the `write` combinator.
 writeStorable :: Storable a => a -> Write
-writeStorable = writeElem WU.writeStorable byteSize
-
+writeStorable a = makeWrite (byteSize a) $ pokeIt
+  where pokeIt = flip poke a . castPtr
 -- | The expression @`write` a@ gives a write action that stores a
 -- value @a@. One needs the type of the value @a@ to be an instance of
 -- `EndianStore`. Proper endian conversion is done irrespective of
 -- what the machine endianness is. The man use of this write is to
 -- serialize data for the consumption of the outside world.
 write :: EndianStore a => a -> Write
-write = writeElem WU.write byteSize
+write a = makeWrite (byteSize a) $ flip store a
 
 -- | The combinator @writeBytes n b@ writes @b@ as the next @n@
 -- consecutive bytes.
 writeBytes :: LengthUnit n => Word8 -> n -> Write
-writeBytes w8 n = WU.writeBytes w8 n `withBound` n
+writeBytes w8 n = makeWrite (inBytes n) memsetIt
+  where memsetIt cptr = memset cptr w8 n
 
 -- | Writes a strict bytestring.
 writeByteString :: ByteString -> Write
-writeByteString = writeElem WU.writeByteString BU.length
-
-------------------- Risky functions --------------------------------
-
--- | This function converts an unsafe write to a safe write by adding
--- a length bound
-withBound  :: LengthUnit l
-           => WU.Write
-           -> l
-           -> Write
-withBound wu l = Write (Sum $ inBytes l, wu)
-{-# INLINE withBound #-}
-
--- | Takes an unsafe element writer, a length estimator and an element
--- and performs a safe write.
-writeElem :: LengthUnit l
-          => (a -> WU.Write)
-          -> (a -> l)
-          -> a
-          -> Write
-writeElem wa wLen a = wa a `withBound` wLen a
-{-# INLINE writeElem #-}
-
--- | The function tries to write the given `Write` action on the
--- buffer and returns `True` if successful.
-tryWriting :: Write         -- ^ The write action.
-           -> CryptoBuffer  -- ^ The buffer to which the bytes are to
-                            -- be written.
-           -> IO Bool
-tryWriting (Write (summ, wr)) (CryptoBuffer sz cptr)
-  | getSum summ > sz = return False
-  | otherwise        = WU.runWrite cptr wr >> return True
+writeByteString bs = makeWrite (BU.length bs) $  BU.unsafeCopyToCryptoPtr bs

--- a/raaz-core/raaz-core.cabal
+++ b/raaz-core/raaz-core.cabal
@@ -66,6 +66,7 @@ library
                  , Raaz.Core.ByteSource
                  , Raaz.Core.Classes
                  , Raaz.Core.DH
+                 , Raaz.Core.Gymnastics
                  , Raaz.Core.Memory
                  , Raaz.Core.Parse
                  , Raaz.Core.Parse.Applicative


### PR DESCRIPTION
Abstracted out the main idea in pointer manipulation that is used by
parsers and writers. The paradigm is general and hence can be used for
many things.
