### PR TITLE
Declare more accurate version bounds

### DIFF
--- a/raaz.cabal
+++ b/raaz.cabal
@@ -146,12 +146,16 @@ library
                -- , Raaz.Cipher.Salsa20.Instances
                -- , Raaz.Cipher.AES.Block.Internal
                , Paths_raaz
-  build-depends: base                           >= 4.5  && < 5.0
-               , bytestring                     >= 0.9
-               , deepseq
-               , mtl                            >= 2.1
-               , transformers
-               , vector
+  build-depends: base                           >= 4.6  && < 4.10
+               , bytestring                     >= 0.9  && < 0.11
+               , deepseq                        >= 1.1  && < 1.5
+               , mtl                            >= 2.1  && < 2.3
+               , vector                         >= 0.7.1 && < 0.12
+
+  if impl(ghc < 8)
+    -- 'transformers' needed for "Control.Monad.IO.Class" only
+    -- starting with base-4.9 we don't need 'transformers' anymore
+    build-depends: transformers
 
   c-sources: cbits/raaz/core/endian.c
            -- hash implementations
@@ -173,7 +177,7 @@ library
 executable checksum
   hs-source-dirs: bin
   main-is: checksum.lhs
-  build-depends: base     >= 4.5 && < 5.0
+  build-depends: base
                , raaz     == 0.0.2
 
 test-Suite spec
@@ -201,8 +205,8 @@ test-Suite spec
                , Raaz.Hash.Blake256Spec
 
 
-  build-depends: base                           >= 4.5 && < 5.0
-               , bytestring                     >= 0.9
+  build-depends: base
+               , bytestring
                , HUnit                          >= 1.2
                , QuickCheck                     >= 2.4
                , hspec


### PR DESCRIPTION
The previous version bounds were inaccurate and allowed the cabal
solver to pick configurations which would fail to compile.