### PR TITLE
Add stack.yml file with lts-6.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ TAGS
 *test
 .hpc
 cabal.sandbox.config
+.stack-work

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+packages:
+- '.'
+resolver: lts-6.9


### PR DESCRIPTION
Also add ./stack-work to gitignore

I hope PR from master is fine, since this should be a minor change.
Also, I cannot claim to have cross-tested the warnings I got with those one would get on building with `cabal`, since I don't have it.
`stack test` works, but the response has the queer `pending` thing (not sure if it exists with cabal as well):
```
103 examples, 0 failures, 1 pending
```

Update: About moving the build to `stack`, [here's](https://github.com/sakshamsharma/acehack/blob/master/.travis.yml) the `.travis.yml` which I use. Once these steps are done, `stack build` is easily done inside the build container.
Also, there's a need to override some steps in travis' build, otherwise it automatically tries to call `cabal update`, `cabal build` and whatnot. Defeats the purpose, kind of.

Update2: [Here's](https://github.com/jaspervdj/hakyll/blob/master/.travis.yml) the travis.yml file which I once added to [hakyll](https://github.com/jaspervdj/hakyll), it is exactly what's needed here. But I'm not sure about the *huge* current file, it sure must be doing something which this stack-based one lacks as of now.