### PR TITLE
add Dest and Src types

### DIFF
--- a/Raaz/Cipher/AES/Recommendation.hs
+++ b/Raaz/Cipher/AES/Recommendation.hs
@@ -16,11 +16,11 @@ import           Raaz.Cipher.Internal
 import           Raaz.Cipher.AES.Internal
 import qualified Raaz.Cipher.AES.CBC.Implementation.CPortable as CPCBC
 
-instance Recommendation (AES 128 CBC) where
+instance Recommendation (AES 128 'CBC) where
          recommended _ = CPCBC.aes128cbcI
 
-instance Recommendation (AES 192 CBC) where
+instance Recommendation (AES 192 'CBC) where
          recommended _ = CPCBC.aes192cbcI
 
-instance Recommendation (AES 256 CBC) where
+instance Recommendation (AES 256 'CBC) where
          recommended _ = CPCBC.aes256cbcI

--- a/Raaz/Core/Memory.hs
+++ b/Raaz/Core/Memory.hs
@@ -329,12 +329,12 @@ instance ( Memory ma
 -- | Copy data from a given memory location to the other. The first
 -- argument is destionation and the second argument is source to match
 -- with the convention followed in memcpy.
-copyMemory :: Memory m => m -- ^ Destination
-                       -> m -- ^ Source
+copyMemory :: Memory m => Dest m -- ^ Destination
+                       -> Src  m -- ^ Source
                        -> IO ()
-copyMemory dest src = memcpy (underlyingPtr dest) (underlyingPtr src) sz
-  where sz       = twistMonoidValue $ getAlloc src
-        getAlloc :: Memory m => m -> Alloc m
+copyMemory dmem smem = memcpy (underlyingPtr <$> dmem) (underlyingPtr <$> smem) sz
+  where sz       = twistMonoidValue $ getAlloc smem
+        getAlloc :: Memory m => Src m -> Alloc m
         getAlloc _ = memoryAlloc
 
 -- | Perform an action which makes use of this memory. The memory

--- a/Raaz/Core/Types.hs
+++ b/Raaz/Core/Types.hs
@@ -16,14 +16,18 @@ module Raaz.Core.Types
        , module Raaz.Core.Types.Pointer
          -- * Tuples with length encoded in their types.
        , module Raaz.Core.Types.Tuple
+         -- * Types to distinguish between source and target of a copy instruction.
+       , module Raaz.Core.Types.Copying
        , Describable(..)
        ) where
+
 
 import Raaz.Core.Types.Describe
 import Raaz.Core.Types.Equality
 import Raaz.Core.Types.Endian
 import Raaz.Core.Types.Pointer
 import Raaz.Core.Types.Tuple
+import Raaz.Core.Types.Copying
 
 -- $timingSafeEquality$
 --

--- a/Raaz/Core/Types.hs
+++ b/Raaz/Core/Types.hs
@@ -5,14 +5,8 @@
 --
 
 module Raaz.Core.Types
-       ( -- * Timing safe equality checking.
-         -- $timingSafeEquality$
-         module Raaz.Core.Types.Equality
-         -- * Endianess aware types.
-         -- $endianness$
+       ( module Raaz.Core.Types.Equality
        , module Raaz.Core.Types.Endian
-         -- * The pointer type and Length offsets.
-         -- $typesafeLength$
        , module Raaz.Core.Types.Pointer
        , module Raaz.Core.Types.Tuple
        , module Raaz.Core.Types.Copying
@@ -27,53 +21,5 @@ import Raaz.Core.Types.Endian
 import Raaz.Core.Types.Pointer
 import Raaz.Core.Types.Tuple
 import Raaz.Core.Types.Copying( Src, Dest, source, destination)
-
--- $timingSafeEquality$
---
--- We need a consistent way to build timing safe equality
--- comparisons. The type class `Equality` plays the role of `Eq` for
--- us. The comparison result is of type `Result` and not `Bool` so as
--- to avoid timing attacks due to short-circuting of the
--- AND-operation.
---
--- The `Result` type is an opaque type to avoid the user from
--- compromising the equality comparisons by pattern matching on it. To
--- combine the results of two comparisons one can use the monoid
--- instance of `Result`, i.e. if @r1@ and @r2@ are the results of two
--- comparisons then @r1 `mappend` r2@ essentially takes the AND of
--- these results but this and is not short-circuited and is timing
--- independent.
---
--- Instance for basic word types are provided by the library and users
--- are expected to build the `Equality` instances of compound types by
--- combine the results of comparisons using the monoid instance of
--- `Result`. We also give timing safe equality comparisons for
--- `Vector` types using the `eqVector` and `oftenCorrectEqVector`
--- functions.  Once an instance for `Equality` is defined for a
--- cryptographically sensitive data type, we define the `Eq` for it
--- indirectly using the `Equality` instance and the operation `===`.
-
-
--- $endianness$
---
--- Cryptographic primitives often consider their input as an array of
--- words of a particular endianness. Endianness is only relevant when
--- the data is being read or written to. It makes sense therefore to
--- keep track of the endianness in the type and perform necessary
--- transformations depending on the endianness of the
--- machine. Such types are captured by the type class `EndianStore`. They
--- support the `load` and `store` combinators that automatically compensates
--- for the endianness of the machine.
---
--- This libraray exposes endian aware variants of `Word32` and
--- `Word64` here and expect other cryptographic types to use such
--- endian explicit types in their definition.
-
-
--- $typesafeLength$
---
--- We have the generic pointer type `Pointer` and distinguish between
--- different length units at the type level. This helps in to avoid a
--- lot of length conversion errors.
 
 {-# ANN module "HLint: ignore Use import/export shortcut" #-}

--- a/Raaz/Core/Types.hs
+++ b/Raaz/Core/Types.hs
@@ -17,7 +17,7 @@ module Raaz.Core.Types
          -- * Tuples with length encoded in their types.
        , module Raaz.Core.Types.Tuple
          -- * Types to distinguish between source and target of a copy instruction.
-       , module Raaz.Core.Types.Copying
+       , Src, Dest, source, destination
        , Describable(..)
        ) where
 

--- a/Raaz/Core/Types.hs
+++ b/Raaz/Core/Types.hs
@@ -14,10 +14,9 @@ module Raaz.Core.Types
          -- * The pointer type and Length offsets.
          -- $typesafeLength$
        , module Raaz.Core.Types.Pointer
-         -- * Tuples with length encoded in their types.
        , module Raaz.Core.Types.Tuple
-         -- * Types to distinguish between source and target of a copy instruction.
-       , Src, Dest, source, destination
+       , module Raaz.Core.Types.Copying
+     --  , Src, Dest, source, destination
        , Describable(..)
        ) where
 
@@ -27,7 +26,7 @@ import Raaz.Core.Types.Equality
 import Raaz.Core.Types.Endian
 import Raaz.Core.Types.Pointer
 import Raaz.Core.Types.Tuple
-import Raaz.Core.Types.Copying
+import Raaz.Core.Types.Copying( Src, Dest, source, destination)
 
 -- $timingSafeEquality$
 --
@@ -76,6 +75,5 @@ import Raaz.Core.Types.Copying
 -- We have the generic pointer type `Pointer` and distinguish between
 -- different length units at the type level. This helps in to avoid a
 -- lot of length conversion errors.
-
 
 {-# ANN module "HLint: ignore Use import/export shortcut" #-}

--- a/Raaz/Core/Types/Copying.hs
+++ b/Raaz/Core/Types/Copying.hs
@@ -1,0 +1,19 @@
+-- | Consider a copy operation that involves copying data between two
+-- entities of the same type. If the source and target is confused
+-- this can lead to bugs. The types here are to avoid such bugs.
+
+module Raaz.Core.Types.Copying
+       ( Src, Dest, src, dest
+       ) where
+
+-- | The source of a copy operation.
+newtype Src  a = Src a
+-- | smart constructor for source
+src :: a -> Src a
+src = Src
+
+-- | The destination of a copy operation.
+newtype Dest a = Dest a
+-- | smart constructor for destionation.
+dest :: a -> Dest a
+dest = Dest

--- a/Raaz/Core/Types/Copying.hs
+++ b/Raaz/Core/Types/Copying.hs
@@ -1,19 +1,33 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
--- | Consider a copy operation that involves copying data between two
--- entities of the same type. If the source and target is confused
--- this can lead to bugs. The types here are to avoid such bugs.
-
+-- | Types to avoid source destination confusion while copying.
 module Raaz.Core.Types.Copying
-       ( Src(..), Dest(..), source, destination
+       (
+         -- * Copying.
+         -- $copyconvention$
+         Src(..), Dest(..), source, destination
        ) where
 
 import Foreign.Storable ( Storable )
 
--- | The source of a copy operation.
+-- $copyconvention$
 --
--- Note to Developers of Raaz: Since the `Src` type inherits the
--- Storable instance of the base type, one can use this type in
--- foreign functions.
+-- Consider a copy operation that involves copying data between two
+-- entities of the same type. If the source and target is confused
+-- this can lead to bugs. The types `Src` and `Dest` helps in avoiding
+-- this confusion. The convention that we follow is that copy function
+-- mark its destination and source explicitly at the type level. The
+-- actual constructors for the type `Src` and `Dest` are not available
+-- to users of the library. Instead they use the smart constructors
+-- `source` and `destination` when passing arguments to these
+-- functions.
+--
+-- The developers of the raaz library do have access to the
+-- constructors. However, it is unlikely one would need it. Since both
+-- `Src` and `Desc` derive the underlying `Storable` instance, one can
+-- mark `Src` and `Dest` in calls to `FFI` functions as well.
+
+
+-- | The source of a copy operation.
 newtype Src  a = Src { unSrc :: a } deriving Storable
 
 -- | smart constructor for source

--- a/Raaz/Core/Types/Copying.hs
+++ b/Raaz/Core/Types/Copying.hs
@@ -3,17 +3,23 @@
 -- this can lead to bugs. The types here are to avoid such bugs.
 
 module Raaz.Core.Types.Copying
-       ( Src, Dest, src, dest
+       ( Src(..), Dest(..), source, destination
        ) where
 
 -- | The source of a copy operation.
-newtype Src  a = Src a
+newtype Src  a = Src { unSrc :: a }
 -- | smart constructor for source
-src :: a -> Src a
-src = Src
+source :: a -> Src a
+source = Src
+
+instance Functor Src where
+  fmap f = Src . f . unSrc
 
 -- | The destination of a copy operation.
-newtype Dest a = Dest a
+newtype Dest a = Dest { unDest :: a }
 -- | smart constructor for destionation.
-dest :: a -> Dest a
-dest = Dest
+destination :: a -> Dest a
+destination = Dest
+
+instance Functor Dest where
+  fmap f = Dest . f . unDest

--- a/Raaz/Core/Types/Copying.hs
+++ b/Raaz/Core/Types/Copying.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Consider a copy operation that involves copying data between two
 -- entities of the same type. If the source and target is confused
 -- this can lead to bugs. The types here are to avoid such bugs.
@@ -6,8 +7,9 @@ module Raaz.Core.Types.Copying
        ( Src(..), Dest(..), source, destination
        ) where
 
+import Foreign.Storable ( Storable )
 -- | The source of a copy operation.
-newtype Src  a = Src { unSrc :: a }
+newtype Src  a = Src { unSrc :: a } deriving Storable
 -- | smart constructor for source
 source :: a -> Src a
 source = Src
@@ -16,7 +18,7 @@ instance Functor Src where
   fmap f = Src . f . unSrc
 
 -- | The destination of a copy operation.
-newtype Dest a = Dest { unDest :: a }
+newtype Dest a = Dest { unDest :: a } deriving Storable
 -- | smart constructor for destionation.
 destination :: a -> Dest a
 destination = Dest

--- a/Raaz/Core/Types/Copying.hs
+++ b/Raaz/Core/Types/Copying.hs
@@ -8,8 +8,14 @@ module Raaz.Core.Types.Copying
        ) where
 
 import Foreign.Storable ( Storable )
+
 -- | The source of a copy operation.
+--
+-- Note to Developers of Raaz: Since the `Src` type inherits the
+-- Storable instance of the base type, one can use this type in
+-- foreign functions.
 newtype Src  a = Src { unSrc :: a } deriving Storable
+
 -- | smart constructor for source
 source :: a -> Src a
 source = Src
@@ -18,7 +24,12 @@ instance Functor Src where
   fmap f = Src . f . unSrc
 
 -- | The destination of a copy operation.
+--
+-- Note to Developers of Raaz: Since the `Dest` type inherits the
+-- Storable instance of the base type, one can use this type in
+-- foreign functions.
 newtype Dest a = Dest { unDest :: a } deriving Storable
+
 -- | smart constructor for destionation.
 destination :: a -> Dest a
 destination = Dest

--- a/Raaz/Core/Types/Endian.hs
+++ b/Raaz/Core/Types/Endian.hs
@@ -7,7 +7,9 @@
 {-# LANGUAGE TypeFamilies               #-}
 
 module Raaz.Core.Types.Endian
-       ( EndianStore(..)
+       ( -- * Endianess aware types.
+         -- $endianness$
+         EndianStore(..)
        -- ** Endian explicit word types.
        , LE, BE, littleEndian, bigEndian
        -- ** Helper functions for endian aware storing and loading.
@@ -31,6 +33,23 @@ import qualified Data.Vector.Generic.Mutable as GVM
 import           Raaz.Core.MonoidalAction
 import           Raaz.Core.Types.Pointer
 import           Raaz.Core.Types.Equality
+
+
+-- $endianness$
+--
+-- Cryptographic primitives often consider their input as an array of
+-- words of a particular endianness. Endianness is only relevant when
+-- the data is being read or written to. It makes sense therefore to
+-- keep track of the endianness in the type and perform necessary
+-- transformations depending on the endianness of the
+-- machine. Such types are captured by the type class `EndianStore`. They
+-- support the `load` and `store` combinators that automatically compensates
+-- for the endianness of the machine.
+--
+-- This libraray exposes endian aware variants of `Word32` and
+-- `Word64` here and expect other cryptographic types to use such
+-- endian explicit types in their definition.
+
 
 -- | This class is the starting point of an endian agnostic interface
 -- to basic cryptographic data types. Endianness only matters when we

--- a/Raaz/Core/Types/Equality.hs
+++ b/Raaz/Core/Types/Equality.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts      #-}
 module Raaz.Core.Types.Equality
-       ( Equality(..), (===)
+       ( -- * Timing safe equality checking.
+         -- $timingSafeEquality$
+         Equality(..), (===)
        -- ** The result of comparion.
        , Result
        -- ** Comparing vectors.
@@ -21,6 +23,35 @@ import qualified Data.Vector.Generic         as G
 import qualified Data.Vector.Generic.Mutable as GM
 import           Data.Vector.Unboxed         ( MVector(..), Vector, Unbox )
 import           Data.Word
+
+
+
+-- $timingSafeEquality$
+--
+-- We need a consistent way to build timing safe equality
+-- comparisons. The type class `Equality` plays the role of `Eq` for
+-- us. The comparison result is of type `Result` and not `Bool` so as
+-- to avoid timing attacks due to short-circuting of the
+-- AND-operation.
+--
+-- The `Result` type is an opaque type to avoid the user from
+-- compromising the equality comparisons by pattern matching on it. To
+-- combine the results of two comparisons one can use the monoid
+-- instance of `Result`, i.e. if @r1@ and @r2@ are the results of two
+-- comparisons then @r1 `mappend` r2@ essentially takes the AND of
+-- these results but this and is not short-circuited and is timing
+-- independent.
+--
+-- Instance for basic word types are provided by the library and users
+-- are expected to build the `Equality` instances of compound types by
+-- combine the results of comparisons using the monoid instance of
+-- `Result`. We also give timing safe equality comparisons for
+-- `Vector` types using the `eqVector` and `oftenCorrectEqVector`
+-- functions.  Once an instance for `Equality` is defined for a
+-- cryptographically sensitive data type, we define the `Eq` for it
+-- indirectly using the `Equality` instance and the operation `===`.
+
+
 
 -- | The result of a comparison. This is an opaque type and the monoid instance essentially takes
 -- AND of two comparisons in a timing safe way.

--- a/Raaz/Core/Types/Pointer.hs
+++ b/Raaz/Core/Types/Pointer.hs
@@ -36,6 +36,7 @@ import System.IO             (hGetBuf, Handle)
 
 import Raaz.Core.MonoidalAction
 import Raaz.Core.Types.Equality
+import Raaz.Core.Types.Copying
 
 -- Developers notes: I assumes that word alignment is alignment
 -- safe. If this is not the case one needs to fix this to avoid
@@ -262,29 +263,29 @@ hFillBuf handle cptr bufSize = BYTES <$> hGetBuf handle cptr bytes
 
 -- | Some common PTR functions abstracted over type safe length.
 foreign import ccall unsafe "string.h memcpy" c_memcpy
-    :: Pointer -> Pointer -> BYTES Int -> IO Pointer
+    :: Dest Pointer -> Src Pointer -> BYTES Int -> IO Pointer
 
 -- | Copy between pointers.
 memcpy :: LengthUnit l
-       => Pointer -- ^ Dest
-       -> Pointer -- ^ Src
-       -> l         -- ^ Number of Bytes to copy
+       => Dest Pointer -- ^ destination
+       -> Src  Pointer -- ^ src
+       -> l            -- ^ Number of Bytes to copy
        -> IO ()
-memcpy p q = void . c_memcpy p q . inBytes
+memcpy dest src = void . c_memcpy dest src . inBytes
 
-{-# SPECIALIZE memcpy :: Pointer -> Pointer -> BYTES Int -> IO () #-}
+{-# SPECIALIZE memcpy :: Dest Pointer -> Src Pointer -> BYTES Int -> IO () #-}
 
 foreign import ccall unsafe "string.h memmove" c_memmove
-    :: Pointer -> Pointer -> BYTES Int -> IO Pointer
+    :: Dest Pointer -> Src Pointer -> BYTES Int -> IO Pointer
 
 -- | Move between pointers.
 memmove :: LengthUnit l
-        => Pointer -- ^ Dest
-        -> Pointer -- ^ Src
-        -> l         -- ^ Number of Bytes to copy
+        => Dest Pointer -- ^ destination
+        -> Src Pointer  -- ^ source
+        -> l            -- ^ Number of Bytes to copy
         -> IO ()
-memmove p q = void . c_memmove p q . inBytes
-{-# SPECIALIZE memmove :: Pointer -> Pointer -> BYTES Int -> IO () #-}
+memmove dest src = void . c_memmove dest src . inBytes
+{-# SPECIALIZE memmove :: Dest Pointer -> Src Pointer -> BYTES Int -> IO () #-}
 
 foreign import ccall unsafe "string.h memset" c_memset
     :: Pointer -> Word8 -> BYTES Int -> IO Pointer

--- a/Raaz/Core/Types/Pointer.hs
+++ b/Raaz/Core/Types/Pointer.hs
@@ -5,7 +5,11 @@
 {-# LANGUAGE CPP                        #-}
 
 module Raaz.Core.Types.Pointer
-       ( -- ** The pointer type.
+       (
+         -- * The pointer type and Length offsets.
+         -- $typesafeLength$
+
+         -- ** The pointer type.
          Pointer
          -- ** Type safe length units.
        , LengthUnit(..)
@@ -37,6 +41,14 @@ import System.IO             (hGetBuf, Handle)
 import Raaz.Core.MonoidalAction
 import Raaz.Core.Types.Equality
 import Raaz.Core.Types.Copying
+
+-- $typesafeLength$
+--
+-- We have the generic pointer type `Pointer` and distinguish between
+-- different length units at the type level. This helps in to avoid a
+-- lot of length conversion errors.
+
+
 
 -- Developers notes: I assumes that word alignment is alignment
 -- safe. If this is not the case one needs to fix this to avoid

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -111,6 +111,7 @@ library
                , Raaz.Core.Types.Equality
                , Raaz.Core.Types.Endian
                , Raaz.Core.Types.Describe
+               , Raaz.Core.Types.Copying
 	       --
 	       -- Hashes
 	       --

--- a/spec/Raaz/Cipher/AESSpec.hs
+++ b/spec/Raaz/Cipher/AESSpec.hs
@@ -82,7 +82,7 @@ aes128cbcSpec = do
        ( "3ff1caa1681fac09120eca307586e1a7"  :: Base16 )
 
   where encryptsTo :: (Format fmt1, Format fmt2)
-                   => fmt1 -> fmt2 -> Key (AES 128 CBC) -> Spec
+                   => fmt1 -> fmt2 -> Key (AES 128 'CBC) -> Spec
         encryptsTo = C.encryptsTo aes128cbc
 
 ------------------ AES 192 CBC ---------------------------
@@ -116,7 +116,7 @@ aes192cbcSpec = do
        ( "08b0e27988598881d920a9e64f5615cd" :: Base16 )
 
   where encryptsTo :: (Format fmt1, Format fmt2)
-                   => fmt1 -> fmt2 -> Key (AES 192 CBC) -> Spec
+                   => fmt1 -> fmt2 -> Key (AES 192 'CBC) -> Spec
         encryptsTo = C.encryptsTo aes192cbc
 
 ------------------ AES 192 CBC ---------------------------
@@ -150,5 +150,5 @@ aes256cbcSpec = do
        ( "b2eb05e2c39be9fcda6c19078c6a9d1b" :: Base16 )
 
   where encryptsTo :: (Format fmt1, Format fmt2)
-                   => fmt1 -> fmt2 -> Key (AES 256 CBC) -> Spec
+                   => fmt1 -> fmt2 -> Key (AES 256 'CBC) -> Spec
         encryptsTo = C.encryptsTo aes256cbc

--- a/spec/Raaz/Core/EncodeSpec.hs
+++ b/spec/Raaz/Core/EncodeSpec.hs
@@ -37,5 +37,5 @@ spec = do
       "pleasure." `shouldEncodeTo` ("cGxlYXN1cmUu" :: Base64)
       "leasure."  `shouldEncodeTo` ("bGVhc3VyZS4=" :: Base64)
       "easure."   `shouldEncodeTo` ("ZWFzdXJlLg==" :: Base64)
-      "asure." 	  `shouldEncodeTo` ("YXN1cmUu"     :: Base64)
-      "sure." 	  `shouldEncodeTo` ("c3VyZS4="     :: Base64)
+      "asure."    `shouldEncodeTo` ("YXN1cmUu"     :: Base64)
+      "sure."     `shouldEncodeTo` ("c3VyZS4="     :: Base64)


### PR DESCRIPTION
Using the newtypes Dest and Src we now distinguish the source and destination types in various copy instructions.