### PR TITLE
direct copying between buffers for EndianStore elements.

### DIFF
--- a/Raaz/Core/Types/Endian.hs
+++ b/Raaz/Core/Types/Endian.hs
@@ -70,14 +70,14 @@ class Storable w => EndianStore w where
   -- | Load the value from the location pointed by the pointer.
   load  :: Pointer -> IO w
 
-  -- | Copy a value for a pointer to another. The first argument is not
-  -- inspected and is only present for the type checker. This function
+  -- | Copy values of this type for a pointer to another. This function
   -- should take care of performing appropriate endian conversion. For
   -- example, if the type `w` was LE Word32, irrespective of what the
   -- underlying architecture is, if the source pointer contains data
   -- `0x01 0x00 0x00 0x00', it should store in the destination pointer
   -- the value `0x01 :: Word32`. In other words, the following law
-  -- should essentially be true (the code fails because it is not able to infer the t.
+  -- should essentially be true (the code fails because it is not able
+  -- to infer the t.
   --
   -- >
   -- > copy u (Dest dptr) (Src sptr) = loadIt u >>= poke dptr

--- a/Raaz/Core/Types/Endian.hs
+++ b/Raaz/Core/Types/Endian.hs
@@ -17,6 +17,7 @@ module Raaz.Core.Types.Endian
        , loadFrom, loadFromIndex
        ) where
 
+import           Control.Applicative
 import           Control.DeepSeq             ( NFData)
 import           Control.Monad               ( liftM )
 import           Data.Bits
@@ -192,8 +193,8 @@ foreign import ccall unsafe "raaz/core/endian.h raazLoadLE32"
 foreign import ccall unsafe "raaz/core/endian.h raazStoreLE32"
   c_storeLE32 :: Pointer -> Word32 -> IO ()
 
-foreign import ccall unsafe "raaz/core/endian.h raazCopyLE32"
-  c_copyFromLE32 :: Int -> Dest (Ptr (LE Word32)) -> Src Pointer -> Int -> IO ()
+foreign import ccall unsafe "raaz/core/endian.h raazCopyFromLE32"
+  c_copyFromLE32 ::  Dest (Ptr (LE Word32)) -> Src Pointer -> Int -> IO ()
 
 instance EndianStore (LE Word32) where
   load             = fmap LE .  c_loadLE32
@@ -208,7 +209,7 @@ foreign import ccall unsafe "raaz/core/endian.h raazLoadBE32"
 foreign import ccall unsafe "raaz/core/endian.h raazStoreBE32"
   c_storeBE32 :: Pointer -> Word32 -> IO ()
 
-foreign import ccall unsafe "raaz/core/endian.h raazCopyBE32"
+foreign import ccall unsafe "raaz/core/endian.h raazCopyFromBE32"
   c_copyFromBE32 :: Dest (Ptr (BE Word32)) -> Src Pointer -> Int -> IO ()
 
 instance EndianStore (BE Word32) where
@@ -224,7 +225,7 @@ foreign import ccall unsafe "raaz/core/endian.h raazLoadLE64"
 foreign import ccall unsafe "raaz/core/endian.h raazStoreLE64"
   c_storeLE64 :: Pointer -> Word64 -> IO ()
 
-foreign import ccall unsafe "raaz/core/endian.h raazCopyLE64"
+foreign import ccall unsafe "raaz/core/endian.h raazCopyFromLE64"
   c_copyFromLE64 :: Dest (Ptr (LE Word64)) -> Src Pointer -> Int -> IO ()
 
 instance EndianStore (LE Word64) where
@@ -240,7 +241,7 @@ foreign import ccall unsafe "raaz/core/endian.h raazLoadBE64"
 foreign import ccall unsafe "raaz/core/endian.h raazStoreBE64"
   c_storeBE64 :: Pointer -> Word64 -> IO ()
 
-foreign import ccall unsafe "raaz/core/endian.h raazCopyBE64"
+foreign import ccall unsafe "raaz/core/endian.h raazCopyFromBE64"
   c_copyFromBE64 :: Dest (Ptr (BE Word64)) -> Src Pointer -> Int -> IO ()
 
 instance EndianStore (BE Word64) where

--- a/Raaz/Core/Types/Tuple.hs
+++ b/Raaz/Core/Types/Tuple.hs
@@ -25,11 +25,12 @@ import           Data.Proxy
 
 import qualified Data.Vector.Unboxed as V
 import           GHC.TypeLits
-import           Foreign.Ptr                 ( castPtr      )
+import           Foreign.Ptr                 ( castPtr, Ptr )
 import           Foreign.Storable            ( Storable(..) )
 import           Prelude hiding              ( length       )
 
 
+import Raaz.Core.Types.Copying
 import Raaz.Core.Types.Equality
 import Raaz.Core.Types.Endian
 import Raaz.Core.Write
@@ -123,6 +124,11 @@ instance (V.Unbox a, EndianStore a, KnownNat dim)
   store cptr tup = unsafeWrite writeTup cptr
     where writeTup = writeVector $ unTuple tup
 
+  copyFromBytes dest src n = copyFromBytes (destPtr dest) src $ nos dest undefined
+       where destPtr :: Dest (Ptr (Tuple dim a)) -> Dest (Ptr a)
+             nos     :: Dest (Ptr (Tuple dim a)) -> Tuple dim a -> Int
+             destPtr = fmap castPtr
+             nos _ w = dimension w * n
 -- | Construct a tuple out of the list. This function is unsafe and
 -- will result in run time error if the list is not of the correct
 -- dimension.

--- a/Raaz/Core/Types/Tuple.hs
+++ b/Raaz/Core/Types/Tuple.hs
@@ -129,6 +129,13 @@ instance (V.Unbox a, EndianStore a, KnownNat dim)
              nos     :: Dest (Ptr (Tuple dim a)) -> Tuple dim a -> Int
              destPtr = fmap castPtr
              nos _ w = dimension w * n
+
+  copyToBytes dest src n = copyToBytes dest (srcPtr src) $ nos src undefined
+       where srcPtr    :: Src (Ptr (Tuple dim a)) -> Src (Ptr a)
+             nos       :: Src (Ptr (Tuple dim a)) -> Tuple dim a -> Int
+             srcPtr    = fmap castPtr
+             nos _ w   = dimension w * n
+
 -- | Construct a tuple out of the list. This function is unsafe and
 -- will result in run time error if the list is not of the correct
 -- dimension.

--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -7,9 +7,9 @@
 # define TOW32(a)               ((uint32_t) a)
 # define TOW64(a)               ((uint64_t) a)
 # define MKW32(a,b,c,d)         (TOW32(a) << 24 | TOW32(b) << 16 | TOW32(c) << 8 | TOW32(d))
-# define MK64(a,b,c,d,e,f,g,h) (                                      \
-   TOW64(a) << 56 | TOW64(b) << 48 | TOW64(c) << 40 | TOW64(d) << 32  \
-   TOW64(e) << 24 | TOW64(f) << 16 | TOW64(g) << 8 | TOW64(h)         )
+# define MKW64(a,b,c,d,e,f,g,h) (                                      \
+   TOW64(a) << 56 | TOW64(b) << 48 | TOW64(c) << 40 | TOW64(d) << 32 | \
+   TOW64(e) << 24 | TOW64(f) << 16 | TOW64(g) << 8  | TOW64(h)         )
 
 # define LoadB(ptr,i)           (((unsigned char *)ptr)[i])
 /* Load from a memory location with proper endian conversion */
@@ -47,7 +47,7 @@
 #endif
 
 /* STORE to a memory location with proper endian conversion */
-# define GetByte(w, i)          ((unsigned char) (w >> (8*(i))))
+# define GetByte(w,j)          ((unsigned char) (w >> (8*(j))))
 # define StoreByte(ptr,i,w,j)   {((unsigned char *)(ptr))[i] = GetByte(w,j); }
 
 # if defined(PLATFORM_LINUX) || defined (PLATFORM_OPENBSD)
@@ -98,7 +98,7 @@
 	StoreByte(ptr,5,w,2);
 	StoreByte(ptr,4,w,3);
 	StoreByte(ptr,3,w,4);
-	StoreByte(ptr,3,w,5);
+	StoreByte(ptr,2,w,5);
 	StoreByte(ptr,1,w,6);
 	StoreByte(ptr,0,w,7);
     }

--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -106,7 +106,7 @@
 #endif
 
 
-void raazCopyLE32(uint32_t *dest, uint32_t *src, int n){
+void raazCopyFromLE32(uint32_t *dest, uint32_t *src, int n){
     while ( n > 0){
         *dest = raazLoadLE32(src);
         ++src; ++dest; --n; /* Move on to the next element. */
@@ -114,7 +114,7 @@ void raazCopyLE32(uint32_t *dest, uint32_t *src, int n){
 }
 
 
-void raazCopyBE32(uint32_t *dest, uint32_t *src, int n){
+void raazCopyFromBE32(uint32_t *dest, uint32_t *src, int n){
     while (n > 0){
         *dest = raazLoadBE32(src);
         ++src; ++dest; --n; /* Move on to the next element. */
@@ -123,7 +123,7 @@ void raazCopyBE32(uint32_t *dest, uint32_t *src, int n){
 }
 
 
-void raazCopyLE64(uint64_t *dest, uint64_t *src, int n){
+void raazCopyFromLE64(uint64_t *dest, uint64_t *src, int n){
     while (n > 0){
         *dest =  raazLoadLE64(src);
         ++src; ++dest; --n;
@@ -132,7 +132,7 @@ void raazCopyLE64(uint64_t *dest, uint64_t *src, int n){
 }
 
 
-void raazCopyBE64(uint64_t *dest, uint64_t *src, int n){
+void raazCopyFromBE64(uint64_t *dest, uint64_t *src, int n){
     while (n > 0){
         *dest = raazLoadBE64(src);
         ++src; ++dest; --n;

--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -4,235 +4,137 @@
  * 32-bit Little endian  load and store
  */
 
-#define HTOLE32(ptr)                  \
-    ((uint32_t)  (ptr[0]))            \
-    |  (((uint32_t) (ptr[1])) << 8)   \
-    |  (((uint32_t) (ptr[2])) << 16)  \
-    |  (((uint32_t) (ptr[3])) << 24)
+# define TOW32(a)               ((uint32_t) a)
+# define TOW64(a)               ((uint64_t) a)
+# define MKW32(a,b,c,d)         (TOW32(a) << 24 | TOW32(b) << 16 | TOW32(c) << 8 | TOW32(d))
+# define MK64(a,b,c,d,e,f,g,h) (                                      \
+   TOW64(a) << 56 | TOW64(b) << 48 | TOW64(c) << 40 | TOW64(d) << 32  \
+   TOW64(e) << 24 | TOW64(f) << 16 | TOW64(g) << 8 | TOW64(h)         )
 
+# define LoadB(ptr,i)           (((unsigned char *)ptr)[i])
+/* Load from a memory location with proper endian conversion */
+#if defined(PLATFORM_LINUX) || defined (PLATFORM_BSD) || defined(PLATFORM_OPENBSD)
 
+    uint32_t raazLoadLE32(uint32_t *wPtr)               { return htole32(*wPtr); }
+    uint32_t raazLoadBE32(uint32_t *wPtr)               { return htobe32(*wPtr); }
+    uint64_t raazLoadLE64(uint64_t *wPtr)               { return htole64(*wPtr); }
+    uint64_t raazLoadBE64(uint64_t *wPtr)               { return htobe64(*wPtr); }
 
-uint32_t raazLoadLE32(uint32_t *wPtr)
-{
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
-  return htole32(*wPtr);
-#else
-  unsigned char *ptr;
-  ptr = (unsigned char *) wPtr;
-  return HTOLE32(ptr);
+#else   /* portable defineition */
+
+    uint32_t raazLoadLE32(uint32_t *ptr)
+    {
+	return MKW32( LoadB(ptr,3), LoadB(ptr,2), LoadB(ptr,1), LoadB(ptr, 0) );
+    }
+
+    uint32_t raazLoadBE32(uint32_t *ptr)
+    {
+	return MKW32( LoadB(ptr,0), LoadB(ptr,1), LoadB(ptr,2), LoadB(ptr, 3) );
+    }
+
+    uint64_t raazLoadLE64(uint64_t *ptr)
+    {
+	return MKW64( LoadB(ptr,7), LoadB(ptr,6), LoadB(ptr,5), LoadB(ptr, 4),
+		      LoadB(ptr,3), LoadB(ptr,2), LoadB(ptr,1), LoadB(ptr, 0));
+    }
+
+    uint64_t raazLoadBE64(uint64_t *ptr)
+    {
+	return  MKW64( LoadB(ptr,0), LoadB(ptr,1), LoadB(ptr,2), LoadB(ptr, 3),
+		       LoadB(ptr,4), LoadB(ptr,5), LoadB(ptr,6), LoadB(ptr, 7));
+    }
+
 #endif
-}
 
-void raazStoreLE32(uint32_t *wPtr , uint32_t w)
-{
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD)
-    *wPtr = le32toh(w);
-#elif defined(PLATFORM_BSD)
-    *wPtr = letoh32(w);
-#else
-    unsigned char *ptr;
-    ptr = (unsigned char *) wPtr;
-    ptr[0] = (unsigned char) w;
-    ptr[1] = (unsigned char) (w >> 8);
-    ptr[2] = (unsigned char) (w >> 16);
-    ptr[3] = (unsigned char) (w >> 24);
+/* STORE to a memory location with proper endian conversion */
+# define GetByte(w, i)          ((unsigned char) (w >> (8*(i))))
+# define StoreByte(ptr,i,w,j)   {((unsigned char *)(ptr))[i] = GetByte(w,j); }
+
+# if defined(PLATFORM_LINUX) || defined (PLATFORM_OPENBSD)
+    void raazStoreLE32(uint32_t *wPtr, uint32_t w) { *wPtr = le32toh(w); }
+    void raazStoreBE32(uint32_t *wPtr, uint32_t w) { *wPtr = be32toh(w); }
+    void raazStoreLE64(uint64_t *wPtr, uint64_t w) { *wPtr = le64toh(w); }
+    void raazStoreBE64(uint64_t *wPtr, uint64_t w) { *wPtr = be64toh(w); }
+
+# elif defined(PLATFORM_BSD)
+    void raazStoreLE32(uint32_t *wPtr, uint32_t w) { *wPtr = letoh32(w); }
+    void raazStoreBE32(uint32_t *wPtr, uint32_t w) { *wPtr = betoh32(w); }
+    void raazStoreLE64(uint64_t *wPtr, uint64_t w) { *wPtr = letoh64(w); }
+    void raazStoreBE64(uint64_t *wPtr, uint64_t w) { *wPtr = betoh64(w); }
+# else
+
+    void raazStoreLE32(uint32_t *ptr, uint32_t w)
+    {
+	StoreByte(ptr,0,w,0);
+	StoreByte(ptr,1,w,1);
+	StoreByte(ptr,2,w,2);
+	StoreByte(ptr,3,w,3);
+    }
+
+    void raazStoreBE32(uint32_t *ptr, uint32_t w)
+    {
+	StoreByte(ptr,3,w,0);
+	StoreByte(ptr,2,w,1);
+	StoreByte(ptr,1,w,2);
+	StoreByte(ptr,0,w,3);
+    }
+
+    void raazStoreLE64(uint64_t *ptr, uint64_t w)
+    {
+	StoreByte(ptr,0,w,0);
+	StoreByte(ptr,1,w,1);
+	StoreByte(ptr,2,w,2);
+	StoreByte(ptr,3,w,3);
+	StoreByte(ptr,4,w,4);
+	StoreByte(ptr,5,w,5);
+	StoreByte(ptr,6,w,6);
+	StoreByte(ptr,7,w,7);
+    }
+
+    void raazStoreBE64(uint64_t *ptr, uint64_t w)
+    {
+	StoreByte(ptr,7,w,0);
+	StoreByte(ptr,6,w,1);
+	StoreByte(ptr,5,w,2);
+	StoreByte(ptr,4,w,3);
+	StoreByte(ptr,3,w,4);
+	StoreByte(ptr,3,w,5);
+	StoreByte(ptr,1,w,6);
+	StoreByte(ptr,0,w,7);
+    }
+
 #endif
-    return;
-}
 
 
-void raazCopyLE32(int n, uint32_t *dest, uint32_t *src)
-{
-    unsigned char *ptr;
+void raazCopyLE32(uint32_t *dest, uint32_t *src, int n){
     while ( n > 0){
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
-        *dest = htole32(*src);
-#else
-        ptr  = (unsigned char *) src;
-        dest = HTOLE32(ptr);
-#endif
+        *dest = raazLoadLE32(src);
         ++src; ++dest; --n; /* Move on to the next element. */
     }
 }
 
 
-
-/*
- * 32-bit Big endian  load and store
- */
-
-#define HTOBE32(ptr)                   \
-    ((uint32_t)  (ptr[3]))             \
-    |    (((uint32_t) (ptr[2])) << 8)  \
-    |    (((uint32_t) (ptr[1])) << 16) \
-    |    (((uint32_t) (ptr[0])) << 24)
-
-uint32_t raazLoadBE32(uint32_t *wPtr)
-{
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
-    return htobe32(*wPtr);
-#else
-  unsigned char *ptr;
-  ptr = (unsigned char *) wPtr;
-  return HTOBE32(ptr)
-#endif
-}
-
-void raazStoreBE32(uint32_t *wPtr , uint32_t w)
-{
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD)
-    *wPtr = be32toh(w);
-#elif defined(PLATFORM_BSD)
-    *wPtr = betoh32(w);
-#else
-    unsigned char *ptr;
-    ptr = (unsigned char *) wPtr;
-    ptr[3] = (unsigned char) w;
-    ptr[2] = (unsigned char) (w >> 8);
-    ptr[1] = (unsigned char) (w >> 16);
-    ptr[0] = (unsigned char) (w >> 24);
-#endif
-    return;
-}
-
-
-void raazCopyBE32(int n, uint32_t *dest, uint32_t *src)
-{
-    unsigned char *ptr;
-
+void raazCopyBE32(uint32_t *dest, uint32_t *src, int n){
     while (n > 0){
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
-        *dest =  htobe32(*src);
-#else
-        ptr   = (unsigned char *) src;
-        *dest = HTOBE32(*src);
-#endif
-        ++src; ++dest; --n;  /* move on to the next element */
+        *dest = raazLoadBE32(src);
+        ++src; ++dest; --n; /* Move on to the next element. */
     }
     return;
 }
 
-/*
- * 64-bit Little endian  load and store
- */
 
-#define HTOLE64(ptr)                        \
-      ((uint64_t) (ptr[0]))                 \
-      |  (((uint64_t) (ptr[1])) << 8)       \
-      |  (((uint64_t) (ptr[2])) << 16)      \
-      |  (((uint64_t) (ptr[3])) << 24)      \
-      |  (((uint64_t) (ptr[4])) << 32)      \
-      |  (((uint64_t) (ptr[5])) << 40)      \
-      |  (((uint64_t) (ptr[6])) << 48)      \
-      |  (((uint64_t) (ptr[7])) << 56)
-
-uint64_t raazLoadLE64(uint64_t *wPtr)
-{
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
-  return htole64(*wPtr);
-#else
-  unsigned char *ptr;
-  ptr = (unsigned char *) wPtr;
-  return HTOLE64(ptr);
-#endif
-}
-
-void raazStoreLE64(uint64_t *wPtr , uint64_t w)
-{
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD)
-    *wPtr = le64toh(w);
-#elif defined(PLATFORM_BSD)
-    *wPtr = letoh64(w);
-#else
-    unsigned char *ptr;
-    ptr = (unsigned char *) wPtr;
-    ptr[0] = (unsigned char) w;
-    ptr[1] = (unsigned char) (w >> 8);
-    ptr[2] = (unsigned char) (w >> 16);
-    ptr[3] = (unsigned char) (w >> 24);
-    ptr[4] = (unsigned char) (w >> 32);
-    ptr[5] = (unsigned char) (w >> 40);
-    ptr[6] = (unsigned char) (w >> 48);
-    ptr[7] = (unsigned char) (w >> 56);
-#endif
-    return;
-}
-
-
-void raazCopyLE64(int n, uint32_t *dest, uint32_t *src)
-{
-    unsigned char *ptr;
+void raazCopyLE64(uint64_t *dest, uint64_t *src, int n){
     while (n > 0){
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
-        *dest =  htole64(*src);
-#else
-        ptr   = (unsigned char *) src;
-        *dest = HTOLE64(ptr);
-#endif
+        *dest =  raazLoadLE64(src);
         ++src; ++dest; --n;
     }
     return;
 }
 
 
-
-/*
- * 64-bit Big endian  load and store
- */
-
-#define HTOBE64(ptr)                       \
-      ((uint64_t) (ptr[7]))                \
-      |  (((uint64_t) (ptr[6])) << 8)      \
-      |  (((uint64_t) (ptr[5])) << 16)     \
-      |  (((uint64_t) (ptr[4])) << 24)     \
-      |  (((uint64_t) (ptr[3])) << 32)     \
-      |  (((uint64_t) (ptr[2])) << 40)     \
-      |  (((uint64_t) (ptr[1])) << 48)     \
-      |  (((uint64_t) (ptr[0])) << 56)
-
-
-uint64_t raazLoadBE64(uint64_t *wPtr)
-{
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
-  return htobe64(*wPtr);
-#else
-  unsigned char *ptr;
-  ptr = (unsigned char *) wPtr;
-  return HTOBE64(ptr);
-#endif
-}
-
-void raazStoreBE64(uint64_t *wPtr , uint64_t w)
-{
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD)
-    *wPtr = be64toh(w);
-#elif defined(PLATFORM_BSD)
-    *wPtr = betoh64(w);
-#else
-    unsigned char *ptr;
-    ptr = (unsigned char *) wPtr;
-    ptr[7] = (unsigned char) w;
-    ptr[6] = (unsigned char) (w >> 8);
-    ptr[5] = (unsigned char) (w >> 16);
-    ptr[4] = (unsigned char) (w >> 24);
-    ptr[3] = (unsigned char) (w >> 32);
-    ptr[2] = (unsigned char) (w >> 40);
-    ptr[1] = (unsigned char) (w >> 48);
-    ptr[0] = (unsigned char) (w >> 56);
-#endif
-    return;
-}
-
-void raazCopyBE64(int n, uint32_t *dest, uint32_t *src)
-{
-    unsigned char *ptr;
+void raazCopyBE64(uint64_t *dest, uint64_t *src, int n){
     while (n > 0){
-#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
-        *dest =  htobe64(*src);
-#else
-        ptr   = (unsigned char *) src;
-        *dest = HTOBE64(ptr);
-#endif
+        *dest = raazLoadBE64(src);
         ++src; ++dest; --n;
     }
     return;

--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -1,7 +1,16 @@
 # include <raaz/core/endian.h>
+
 /*
  * 32-bit Little endian  load and store
  */
+
+#define HTOLE32(ptr)                  \
+    ((uint32_t)  (ptr[0]))            \
+    |  (((uint32_t) (ptr[1])) << 8)   \
+    |  (((uint32_t) (ptr[2])) << 16)  \
+    |  (((uint32_t) (ptr[3])) << 24)
+
+
 
 uint32_t raazLoadLE32(uint32_t *wPtr)
 {
@@ -10,11 +19,7 @@ uint32_t raazLoadLE32(uint32_t *wPtr)
 #else
   unsigned char *ptr;
   ptr = (unsigned char *) wPtr;
-  return ((uint32_t)  (ptr[0]))
-      |  (((uint32_t) (ptr[1])) << 8)
-      |  (((uint32_t) (ptr[2])) << 16)
-      |  (((uint32_t) (ptr[3])) << 24)
-    ;
+  return HTOLE32(ptr);
 #endif
 }
 
@@ -35,9 +40,32 @@ void raazStoreLE32(uint32_t *wPtr , uint32_t w)
     return;
 }
 
+
+void raazCopyLE32(int n, uint32_t *dest, uint32_t *src)
+{
+    unsigned char *ptr;
+    while ( n > 0){
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
+        *dest = htole32(*src);
+#else
+        ptr  = (unsigned char *) src;
+        dest = HTOLE32(ptr);
+#endif
+        ++src; ++dest; --n; /* Move on to the next element. */
+    }
+}
+
+
+
 /*
  * 32-bit Big endian  load and store
  */
+
+#define HTOBE32(ptr)                   \
+    ((uint32_t)  (ptr[3]))             \
+    |    (((uint32_t) (ptr[2])) << 8)  \
+    |    (((uint32_t) (ptr[1])) << 16) \
+    |    (((uint32_t) (ptr[0])) << 24)
 
 uint32_t raazLoadBE32(uint32_t *wPtr)
 {
@@ -46,11 +74,7 @@ uint32_t raazLoadBE32(uint32_t *wPtr)
 #else
   unsigned char *ptr;
   ptr = (unsigned char *) wPtr;
-  return ((uint32_t)  (ptr[3]))
-    |    (((uint32_t) (ptr[2])) << 8)
-    |    (((uint32_t) (ptr[1])) << 16)
-    |    (((uint32_t) (ptr[0])) << 24)
-    ;
+  return HTOBE32(ptr)
 #endif
 }
 
@@ -71,9 +95,36 @@ void raazStoreBE32(uint32_t *wPtr , uint32_t w)
     return;
 }
 
+
+void raazCopyBE32(int n, uint32_t *dest, uint32_t *src)
+{
+    unsigned char *ptr;
+
+    while (n > 0){
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
+        *dest =  htobe32(*src);
+#else
+        ptr   = (unsigned char *) src;
+        *dest = HTOBE32(*src);
+#endif
+        ++src; ++dest; --n;  /* move on to the next element */
+    }
+    return;
+}
+
 /*
  * 64-bit Little endian  load and store
  */
+
+#define HTOLE64(ptr)                        \
+      ((uint64_t) (ptr[0]))                 \
+      |  (((uint64_t) (ptr[1])) << 8)       \
+      |  (((uint64_t) (ptr[2])) << 16)      \
+      |  (((uint64_t) (ptr[3])) << 24)      \
+      |  (((uint64_t) (ptr[4])) << 32)      \
+      |  (((uint64_t) (ptr[5])) << 40)      \
+      |  (((uint64_t) (ptr[6])) << 48)      \
+      |  (((uint64_t) (ptr[7])) << 56)
 
 uint64_t raazLoadLE64(uint64_t *wPtr)
 {
@@ -82,15 +133,7 @@ uint64_t raazLoadLE64(uint64_t *wPtr)
 #else
   unsigned char *ptr;
   ptr = (unsigned char *) wPtr;
-  return ((uint64_t) (ptr[0]))
-      |  (((uint64_t) (ptr[1])) << 8)
-      |  (((uint64_t) (ptr[2])) << 16)
-      |  (((uint64_t) (ptr[3])) << 24)
-      |  (((uint64_t) (ptr[4])) << 32)
-      |  (((uint64_t) (ptr[5])) << 40)
-      |  (((uint64_t) (ptr[6])) << 48)
-      |  (((uint64_t) (ptr[7])) << 56)
-    ;
+  return HTOLE64(ptr);
 #endif
 }
 
@@ -116,9 +159,37 @@ void raazStoreLE64(uint64_t *wPtr , uint64_t w)
 }
 
 
+void raazCopyLE64(int n, uint32_t *dest, uint32_t *src)
+{
+    unsigned char *ptr;
+    while (n > 0){
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
+        *dest =  htole64(*src);
+#else
+        ptr   = (unsigned char *) src;
+        *dest = HTOLE64(ptr);
+#endif
+        ++src; ++dest; --n;
+    }
+    return;
+}
+
+
+
 /*
  * 64-bit Big endian  load and store
  */
+
+#define HTOBE64(ptr)                       \
+      ((uint64_t) (ptr[7]))                \
+      |  (((uint64_t) (ptr[6])) << 8)      \
+      |  (((uint64_t) (ptr[5])) << 16)     \
+      |  (((uint64_t) (ptr[4])) << 24)     \
+      |  (((uint64_t) (ptr[3])) << 32)     \
+      |  (((uint64_t) (ptr[2])) << 40)     \
+      |  (((uint64_t) (ptr[1])) << 48)     \
+      |  (((uint64_t) (ptr[0])) << 56)
+
 
 uint64_t raazLoadBE64(uint64_t *wPtr)
 {
@@ -127,15 +198,7 @@ uint64_t raazLoadBE64(uint64_t *wPtr)
 #else
   unsigned char *ptr;
   ptr = (unsigned char *) wPtr;
-  return ((uint64_t) (ptr[7]))
-      |  (((uint64_t) (ptr[6])) << 8)
-      |  (((uint64_t) (ptr[5])) << 16)
-      |  (((uint64_t) (ptr[4])) << 24)
-      |  (((uint64_t) (ptr[3])) << 32)
-      |  (((uint64_t) (ptr[2])) << 40)
-      |  (((uint64_t) (ptr[1])) << 48)
-      |  (((uint64_t) (ptr[0])) << 56)
-    ;
+  return HTOBE64(ptr);
 #endif
 }
 
@@ -157,5 +220,20 @@ void raazStoreBE64(uint64_t *wPtr , uint64_t w)
     ptr[1] = (unsigned char) (w >> 48);
     ptr[0] = (unsigned char) (w >> 56);
 #endif
+    return;
+}
+
+void raazCopyBE64(int n, uint32_t *dest, uint32_t *src)
+{
+    unsigned char *ptr;
+    while (n > 0){
+#if defined(PLATFORM_LINUX) || defined(PLATFORM_OPENBSD) || defined(PLATFORM_BSD)
+        *dest =  htobe64(*src);
+#else
+        ptr   = (unsigned char *) src;
+        *dest = HTOBE64(ptr);
+#endif
+        ++src; ++dest; --n;
+    }
     return;
 }

--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -111,12 +111,32 @@ void raazCopyFromLE32(uint32_t *dest, uint32_t *src, int n){
         *dest = raazLoadLE32(src);
         ++src; ++dest; --n; /* Move on to the next element. */
     }
+    return;
 }
+
+void raazCopyToLE32(uint32_t *dest, uint32_t *src, int n){
+    while( n > 0) {
+	raazStoreLE32(dest, *src);
+	++src; ++dest; --n; /* Move on to the next element. */
+    }
+    return;
+}
+
 
 
 void raazCopyFromBE32(uint32_t *dest, uint32_t *src, int n){
     while (n > 0){
         *dest = raazLoadBE32(src);
+        ++src; ++dest; --n; /* Move on to the next element. */
+    }
+    return;
+}
+
+
+
+void raazCopyToBE32(uint32_t *dest, uint32_t *src, int n){
+    while (n > 0){
+        raazStoreBE32(dest, *src);
         ++src; ++dest; --n; /* Move on to the next element. */
     }
     return;
@@ -132,9 +152,26 @@ void raazCopyFromLE64(uint64_t *dest, uint64_t *src, int n){
 }
 
 
+void raazCopyToLE64(uint64_t *dest, uint64_t *src, int n){
+    while (n > 0){
+        raazStoreLE64(dest, *src);
+        ++src; ++dest; --n;
+    }
+    return;
+}
+
+
 void raazCopyFromBE64(uint64_t *dest, uint64_t *src, int n){
     while (n > 0){
         *dest = raazLoadBE64(src);
+        ++src; ++dest; --n;
+    }
+    return;
+}
+
+void raazCopyToBE64(uint64_t *dest, uint64_t *src, int n){
+    while (n > 0){
+        raazStoreBE64(dest, *src);
         ++src; ++dest; --n;
     }
     return;

--- a/spec/Common/Utils.hs
+++ b/spec/Common/Utils.hs
@@ -31,6 +31,13 @@ storeCopyAndPeek a = alloc2 (byteSize a) $ \ dest src ->  do
   copyFromBytes (destination dest) (source src) 1
   peek dest
 
+pokeCopyAndLoad :: EndianStore a
+                 => a
+                 -> IO a
+pokeCopyAndLoad a = alloc2 (byteSize a) $ \ dest src ->  do
+  poke src a
+  copyToBytes (destination dest) (source src) 1
+  load dest
 
 basicEndianSpecs :: ( EndianStore a, Show a, Eq a, Arbitrary a)
                   => a -> Spec
@@ -40,6 +47,9 @@ basicEndianSpecs a = do
 
   prop "store, copy followed by peek should return the original value" $ \ x ->
     storeCopyAndPeek (x `asTypeOf` a) `shouldReturn` x
+
+  prop "poke, copy followed by load should return the original value" $ \ x ->
+    pokeCopyAndLoad (x `asTypeOf` a) `shouldReturn` x
 
 
 

--- a/spec/Common/Utils.hs
+++ b/spec/Common/Utils.hs
@@ -32,6 +32,17 @@ storeCopyAndPeek a = alloc2 (byteSize a) $ \ dest src ->  do
   peek dest
 
 
+basicEndianSpecs :: ( EndianStore a, Show a, Eq a, Arbitrary a)
+                  => a -> Spec
+basicEndianSpecs a = do
+  prop "store followed by load returns original value" $ \ x ->
+    storeAndThenLoad (x `asTypeOf` a) `shouldReturn` x
+
+  prop "store, copy followed by peek should return the original value" $ \ x ->
+    storeCopyAndPeek (x `asTypeOf` a) `shouldReturn` x
+
+
+
 -- | Shorten a string to make it readable in tests.
 shortened :: String -> String
 shortened x | l <= 11    = paddedx

--- a/spec/Raaz/Core/Types/WordSpec.hs
+++ b/spec/Raaz/Core/Types/WordSpec.hs
@@ -29,6 +29,9 @@ spec = do
     prop "store followed by load returns original value" $ \ (x :: LE Word32) ->
       storeAndThenLoad x `shouldReturn` x
 
+    prop "store, copy followed by peek should return the original value" $ \ (x :: LE Word32) ->
+      storeCopyAndPeek x `shouldReturn` x
+
     prop "size of encodings of is 4 bytes" $ \ (w :: LE Word32) ->
       B.length (toByteString w) `shouldBe` 4
 
@@ -42,6 +45,10 @@ spec = do
 
     prop "store followed by load returns original value" $ \ (x :: LE Word64) ->
       storeAndThenLoad x `shouldReturn` x
+
+
+    prop "store, copy followed by peek should return the original value" $ \ (x :: LE Word64) ->
+      storeCopyAndPeek x `shouldReturn` x
 
     prop "size of encodings of is 8 bytes" $ \ (w :: LE Word64) ->
       B.length (toByteString w) `shouldBe` 8
@@ -57,6 +64,10 @@ spec = do
     prop "store followed by load returns original value" $ \ (x :: BE Word32) ->
       storeAndThenLoad x `shouldReturn` x
 
+    prop "store, copy followed by peek should return the original value" $ \ (x :: BE Word32) ->
+      storeCopyAndPeek x `shouldReturn` x
+
+
     prop "size of encodings of is 4 bytes" $ \ (w :: BE Word32) ->
       B.length (toByteString w) `shouldBe` 4
 
@@ -70,6 +81,9 @@ spec = do
 
     prop "store followed by load returns original value" $ \ (x :: BE Word64) ->
       storeAndThenLoad x `shouldReturn` x
+
+    prop "store, copy followed by peek should return the original value" $ \ (x :: BE Word64) ->
+      storeCopyAndPeek x `shouldReturn` x
 
     prop "size of encodings of is 8 bytes" $ \ (w :: BE Word64) ->
       B.length (toByteString w) `shouldBe` 8

--- a/spec/Raaz/Core/Types/WordSpec.hs
+++ b/spec/Raaz/Core/Types/WordSpec.hs
@@ -26,11 +26,7 @@ spec = do
 
   describe "32-bit little endian" $ do
 
-    prop "store followed by load returns original value" $ \ (x :: LE Word32) ->
-      storeAndThenLoad x `shouldReturn` x
-
-    prop "store, copy followed by peek should return the original value" $ \ (x :: LE Word32) ->
-      storeCopyAndPeek x `shouldReturn` x
+    basicEndianSpecs (undefined :: LE Word32)
 
     prop "size of encodings of is 4 bytes" $ \ (w :: LE Word32) ->
       B.length (toByteString w) `shouldBe` 4
@@ -43,12 +39,7 @@ spec = do
 
   describe "64-bit little endian" $ do
 
-    prop "store followed by load returns original value" $ \ (x :: LE Word64) ->
-      storeAndThenLoad x `shouldReturn` x
-
-
-    prop "store, copy followed by peek should return the original value" $ \ (x :: LE Word64) ->
-      storeCopyAndPeek x `shouldReturn` x
+    basicEndianSpecs (undefined :: LE Word64)
 
     prop "size of encodings of is 8 bytes" $ \ (w :: LE Word64) ->
       B.length (toByteString w) `shouldBe` 8
@@ -61,12 +52,7 @@ spec = do
 
   describe "32-bit big endian" $ do
 
-    prop "store followed by load returns original value" $ \ (x :: BE Word32) ->
-      storeAndThenLoad x `shouldReturn` x
-
-    prop "store, copy followed by peek should return the original value" $ \ (x :: BE Word32) ->
-      storeCopyAndPeek x `shouldReturn` x
-
+    basicEndianSpecs (undefined :: BE Word32)
 
     prop "size of encodings of is 4 bytes" $ \ (w :: BE Word32) ->
       B.length (toByteString w) `shouldBe` 4
@@ -79,11 +65,7 @@ spec = do
 
   describe "64-bit big endian" $ do
 
-    prop "store followed by load returns original value" $ \ (x :: BE Word64) ->
-      storeAndThenLoad x `shouldReturn` x
-
-    prop "store, copy followed by peek should return the original value" $ \ (x :: BE Word64) ->
-      storeCopyAndPeek x `shouldReturn` x
+    basicEndianSpecs (undefined :: BE Word64)
 
     prop "size of encodings of is 8 bytes" $ \ (w :: BE Word64) ->
       B.length (toByteString w) `shouldBe` 8

--- a/spec/Raaz/Hash/Sha1Spec.hs
+++ b/spec/Raaz/Hash/Sha1Spec.hs
@@ -20,11 +20,7 @@ hmacsTo  = CH.hmacsTo
 spec :: Spec
 spec =  do
 
-  prop "store followed by load returns original value" $ \ (x :: SHA1) ->
-    storeAndThenLoad x `shouldReturn` x
-
-  prop "store, copy followed by peek should return the original value" $ \ (x :: SHA1) ->
-    storeCopyAndPeek x `shouldReturn` x
+  basicEndianSpecs (undefined :: SHA1)
 
   --
   -- Some unit tests

--- a/spec/Raaz/Hash/Sha1Spec.hs
+++ b/spec/Raaz/Hash/Sha1Spec.hs
@@ -23,6 +23,9 @@ spec =  do
   prop "store followed by load returns original value" $ \ (x :: SHA1) ->
     storeAndThenLoad x `shouldReturn` x
 
+  prop "store, copy followed by peek should return the original value" $ \ (x :: SHA1) ->
+    storeCopyAndPeek x `shouldReturn` x
+
   --
   -- Some unit tests
   --

--- a/spec/Raaz/Hash/Sha224Spec.hs
+++ b/spec/Raaz/Hash/Sha224Spec.hs
@@ -17,6 +17,9 @@ spec =  do
   prop "store followed by load returns original value" $ \ (x :: SHA224) ->
     storeAndThenLoad x `shouldReturn` x
 
+  prop "store, copy followed by peek should return the original value" $ \ (x :: SHA224) ->
+    storeCopyAndPeek x `shouldReturn` x
+
   --
   -- Some unit tests
   --

--- a/spec/Raaz/Hash/Sha224Spec.hs
+++ b/spec/Raaz/Hash/Sha224Spec.hs
@@ -14,11 +14,7 @@ hashesTo = CH.hashesTo
 spec :: Spec
 spec =  do
 
-  prop "store followed by load returns original value" $ \ (x :: SHA224) ->
-    storeAndThenLoad x `shouldReturn` x
-
-  prop "store, copy followed by peek should return the original value" $ \ (x :: SHA224) ->
-    storeCopyAndPeek x `shouldReturn` x
+  basicEndianSpecs (undefined :: SHA224)
 
   --
   -- Some unit tests

--- a/spec/Raaz/Hash/Sha256Spec.hs
+++ b/spec/Raaz/Hash/Sha256Spec.hs
@@ -22,6 +22,9 @@ spec =  do
   prop "store followed by load returns original value" $ \ (x :: SHA256) ->
     storeAndThenLoad x `shouldReturn` x
 
+  prop "store, copy followed by peek should return the original value" $ \ (x :: SHA256) ->
+      storeCopyAndPeek x `shouldReturn` x
+
   --
   -- Some unit tests
   --

--- a/spec/Raaz/Hash/Sha256Spec.hs
+++ b/spec/Raaz/Hash/Sha256Spec.hs
@@ -19,11 +19,7 @@ hmacsTo  = CH.hmacsTo
 spec :: Spec
 spec =  do
 
-  prop "store followed by load returns original value" $ \ (x :: SHA256) ->
-    storeAndThenLoad x `shouldReturn` x
-
-  prop "store, copy followed by peek should return the original value" $ \ (x :: SHA256) ->
-      storeCopyAndPeek x `shouldReturn` x
+  basicEndianSpecs (undefined :: SHA256)
 
   --
   -- Some unit tests

--- a/spec/Raaz/Hash/Sha384Spec.hs
+++ b/spec/Raaz/Hash/Sha384Spec.hs
@@ -17,6 +17,9 @@ spec =  do
   prop "store followed by load returns original value" $ \ (x :: SHA384) ->
     storeAndThenLoad x `shouldReturn` x
 
+  prop "store, copy followed by peek should return the original value" $ \ (x :: SHA384) ->
+      storeCopyAndPeek x `shouldReturn` x
+
   --
   -- Some unit tests
   --

--- a/spec/Raaz/Hash/Sha384Spec.hs
+++ b/spec/Raaz/Hash/Sha384Spec.hs
@@ -14,11 +14,7 @@ hashesTo = CH.hashesTo
 spec :: Spec
 spec =  do
 
-  prop "store followed by load returns original value" $ \ (x :: SHA384) ->
-    storeAndThenLoad x `shouldReturn` x
-
-  prop "store, copy followed by peek should return the original value" $ \ (x :: SHA384) ->
-      storeCopyAndPeek x `shouldReturn` x
+  basicEndianSpecs (undefined :: SHA384)
 
   --
   -- Some unit tests

--- a/spec/Raaz/Hash/Sha512Spec.hs
+++ b/spec/Raaz/Hash/Sha512Spec.hs
@@ -20,11 +20,7 @@ hmacsTo  = CH.hmacsTo
 spec :: Spec
 spec =  do
 
-  prop "store followed by load returns original value" $ \ (x :: SHA512) ->
-    storeAndThenLoad x `shouldReturn` x
-
-  prop "store, copy followed by peek should return the original value" $ \ (x :: SHA512) ->
-      storeCopyAndPeek x `shouldReturn` x
+  basicEndianSpecs (undefined :: SHA512)
 
   --
   -- Some unit tests

--- a/spec/Raaz/Hash/Sha512Spec.hs
+++ b/spec/Raaz/Hash/Sha512Spec.hs
@@ -22,6 +22,10 @@ spec =  do
 
   prop "store followed by load returns original value" $ \ (x :: SHA512) ->
     storeAndThenLoad x `shouldReturn` x
+
+  prop "store, copy followed by peek should return the original value" $ \ (x :: SHA512) ->
+      storeCopyAndPeek x `shouldReturn` x
+
   --
   -- Some unit tests
   --


### PR DESCRIPTION
The `EndianStore` class now supports copying between buffers which takes care of endianness. One can use the load and store to define this function however, if used in the context of secure memory, this can lead to secret escaping from the secure memory to the Haskell Heap negating the purpose of secure memory. The copy functions here are implemented either as a memcpy of low level C function. As a result, comparitively lesser secret information escape to the heap.