### PR TITLE
direct initialisation and extraction from memory elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ before_install:
    fi
  - if [ "$HVR_COLLECTION" != "" ]; then
       echo geting cabal.config from the collection of hvr;
-      wget https://raw.githubusercontent.com/hvr/multi-ghc-travis/master/collections/cabal.project."$HVR_COLLECTION" -o cabal.config ;
+      wget https://raw.githubusercontent.com/hvr/multi-ghc-travis/master/collections/cabal.project."$HVR_COLLECTION" -O cabal.config ;
    fi
  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install ghc cabal-install; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,9 +83,9 @@ before_install:
       echo getting the stackage cabal.config;
       wget "https://www.stackage.org/$STACKVER/cabal.config";
    fi
- - if [ "$HVR_COLLECTION" != ""]; then
+ - if [ "$HVR_COLLECTION" != "" ]; then
       echo geting cabal.config from the collection of hvr.
-      wget https://raw.githubusercontent.com/hvr/multi-ghc-travis/master/collections/cabal.project."$HVR_COLLECTION";
+      wget https://raw.githubusercontent.com/hvr/multi-ghc-travis/master/collections/cabal.project."$HVR_COLLECTION" -o cabal.config ;
    fi
  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi
  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install ghc cabal-install; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ before_install:
       wget "https://www.stackage.org/$STACKVER/cabal.config";
    fi
  - if [ "$HVR_COLLECTION" != "" ]; then
-      echo geting cabal.config from the collection of hvr.
+      echo geting cabal.config from the collection of hvr;
       wget https://raw.githubusercontent.com/hvr/multi-ghc-travis/master/collections/cabal.project."$HVR_COLLECTION" -o cabal.config ;
    fi
  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update; fi

--- a/Raaz/Core/Memory.hs
+++ b/Raaz/Core/Memory.hs
@@ -340,9 +340,11 @@ copyMemory dmem smem = memcpy (underlyingPtr <$> dmem) (underlyingPtr <$> smem) 
 withMemory   :: Memory m => (m -> IO a) -> IO a
 withMemory   = withM memoryAlloc
   where withM :: Memory m => Alloc m -> (m -> IO a) -> IO a
-        withM alctr action = allocaBuffer sz $ action . getM
-          where sz     = twistMonoidValue alctr
-                getM   = computeField $ twistFunctorValue alctr
+        withM alctr action = allocaBuffer sz actualAction
+          where sz                 = twistMonoidValue alctr
+                getM               = computeField $ twistFunctorValue alctr
+                wipeIt cptr        = memset cptr 0 sz
+                actualAction  cptr = action (getM cptr) <* wipeIt cptr
 
 
 -- | Similar to `withMemory` but allocates a secure memory for the

--- a/Raaz/Core/Memory.hs
+++ b/Raaz/Core/Memory.hs
@@ -291,12 +291,6 @@ class Memory m where
   -- | Returns the pointer to the underlying buffer.
   underlyingPtr  :: m -> Pointer
 
-class Memory m => Initialisable m v where
-  initialise :: v -> MT m ()
-
-class Memory m => Extractable m v where
-  extract  :: MT m v
-
 instance ( Memory ma, Memory mb ) => Memory (ma, mb) where
     memoryAlloc           = (,) <$> memoryAlloc <*> memoryAlloc
     underlyingPtr (ma, _) =  underlyingPtr ma
@@ -370,7 +364,15 @@ withSecureMemory = withSM memoryAlloc
 -- | A memory location to store a value of type having `Storable`
 -- instance.
 newtype MemoryCell a = MemoryCell { unMemoryCell :: Pointer }
+----------------------- Initialising and Extracting stuff ----------------------
 
+-- | Memories that can be initialised with a value.
+class Memory m => Initialisable m v where
+  initialise :: v -> MT m ()
+
+-- | Memories from which stuff can be extracted.
+class Memory m => Extractable m v where
+  extract  :: MT m v
 
 -- | Perform some pointer action on MemoryCell. Useful while working
 -- with ffi functions.

--- a/Raaz/Core/Memory.hs
+++ b/Raaz/Core/Memory.hs
@@ -460,3 +460,9 @@ instance Storable a => Initialisable (MemoryCell a) a where
 instance Storable a => Extractable (MemoryCell a) a where
   extract = execute $ peek . unMemoryCell
   {-# INLINE extract #-}
+
+instance EndianStore a => InitialisableFromBuffer (MemoryCell a) where
+  initialiser  = readInto 1 . destination . unMemoryCell
+
+instance EndianStore a => ExtractableToBuffer (MemoryCell a) where
+  extractor  = writeFrom 1 . source . unMemoryCell

--- a/Raaz/Core/Transfer.hs
+++ b/Raaz/Core/Transfer.hs
@@ -7,7 +7,10 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Raaz.Core.Transfer
-       ( Write, bytesToWrite, unsafeWrite
+       ( -- * Transfer actions.
+         -- $transfer$
+         -- ** Write action.
+         WriteM, WriteIO, bytesToWrite, unsafeWrite
        , write, writeStorable, writeVector, writeStorableVector
        , writeBytes, writeByteString, skipWrite
        ) where

--- a/Raaz/Core/Transfer.hs
+++ b/Raaz/Core/Transfer.hs
@@ -146,7 +146,7 @@ writeFrom :: (MonadIO m, EndianStore a) => Int -> Src (Ptr a) -> WriteM m
 writeFrom n src = makeWrite (sz undefined src)
                   $ \ ptr -> liftIO  $ copyToBytes (destination ptr) src n
   where sz :: Storable a => a -> Src (Ptr a) -> BYTES Int
-        sz a ptr = toEnum n * byteSize a
+        sz a _ = toEnum n * byteSize a
 
 -- | The vector version of `writeStorable`.
 writeStorableVector :: (Storable a, G.Vector v a, MonadIO m) => v a -> WriteM m
@@ -165,7 +165,8 @@ lifted.
 -- | The vector version of `write`.
 writeVector :: (EndianStore a, G.Vector v a, MonadIO m) => v a -> WriteM m
 {-# INLINE writeVector #-}
-{-# TODO: improve this using the fact that the size is known #-}
+{- TODO: improve this using the fact that the size is known -}
+
 writeVector = G.foldl' foldFunc mempty
   where foldFunc w a =  w <> write a
 {- TODO: Same as in writeStorableVector -}
@@ -241,4 +242,4 @@ readInto :: (EndianStore a, MonadIO m)
 readInto n dest = makeRead (sz undefined dest)
                   $ \ ptr -> liftIO $ copyFromBytes dest (source ptr) n
   where sz :: Storable a => a -> Dest (Ptr a) -> BYTES Int
-        sz a ptr = toEnum n * byteSize a
+        sz a _ = toEnum n * byteSize a

--- a/Raaz/Core/Transfer.hs
+++ b/Raaz/Core/Transfer.hs
@@ -4,13 +4,15 @@
 {-# LANGUAGE TypeSynonymInstances       #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Raaz.Core.Write
+module Raaz.Core.Transfer
        ( Write, bytesToWrite, unsafeWrite
        , write, writeStorable, writeVector, writeStorableVector
        , writeBytes, writeByteString, skipWrite
        ) where
 
+import           Control.Monad.IO.Class
 import           Data.ByteString           (ByteString)
 import           Data.String
 import           Data.ByteString.Internal  (unsafeCreate)
@@ -26,63 +28,72 @@ import           Raaz.Core.Types.Pointer
 import           Raaz.Core.Util.ByteString as BU
 import           Raaz.Core.Encode
 
--- | The monoid for write.
-newtype WriteM = WriteM { unWriteM :: IO () }
+-- | The monoid for transfering.
+newtype TransferM m = TransferM { unTransferM :: m () }
 
-instance Monoid WriteM where
-  mempty        = WriteM $ return ()
+instance Monad m => Monoid (TransferM m) where
+  mempty        = TransferM $ return ()
   {-# INLINE mempty #-}
 
-  mappend wa wb = WriteM $ unWriteM wa >> unWriteM wb
+  mappend wa wb = TransferM $ unTransferM wa >> unTransferM wb
   {-# INLINE mappend #-}
 
-  mconcat = WriteM . mapM_ unWriteM
+  mconcat = TransferM . mapM_ unTransferM
   {-# INLINE mconcat #-}
 
--- | A write action is nothing but an IO action that returns () on
+-- | A action that transfers some stuff. It is nothing but an action that returns () on
 -- input a pointer.
-type WriteAction = Pointer -> WriteM
+type TransferAction m = Pointer -> TransferM m
 
-instance LAction (BYTES Int) WriteAction where
-  m <.> action = action . (m<.>)
+instance Monad m => LAction (BYTES Int) (TransferAction m) where
+  offset <.> action = action . (offset<.>)
   {-# INLINE (<.>) #-}
 
-instance Distributive (BYTES Int) WriteAction
+instance Monad m => Distributive (BYTES Int) (TransferAction m)
 
--- | A write is an action which when executed using `runWrite` writes
--- bytes to the input buffer. It is similar to the `WU.Write` type
--- exposed from the "Raaz.Write.Unsafe" module except that it keeps
--- track of the total bytes that would be written to the buffer if the
--- action is run. The `runWrite` action will raise an error if the
--- buffer it is provided with is of size smaller. `Write`s are monoid
--- and hence can be concatnated using the `<>` operator.
-type Write = SemiR WriteAction (BYTES Int)
+type Transfer m = SemiR (TransferAction m) (BYTES Int)
 
--- | Create a write action.
-makeWrite :: LengthUnit u => u -> (Pointer -> IO ()) -> Write
-{-# INLINE makeWrite #-}
-makeWrite sz action = SemiR (WriteM . action) $ inBytes sz
+
+makeTransfer :: LengthUnit u => u -> (Pointer -> m ()) -> Transfer m
+{-# INLINE makeTransfer #-}
+makeTransfer sz action = SemiR (TransferM . action) $ inBytes sz
+
+
+-------------------------- Monoid for writing stuff --------------------------------------
+
+-- | A write is an action which when executed using writes
+-- bytes to its input buffer. `Write`s are monoid and hence can be
+-- concatnated using the `<>` operator.
+newtype WriteM m = WriteM { unWriteM :: Transfer m } deriving Monoid
+
+-- | The default write action.
+type Write = WriteM IO
 
 -- | Returns the bytes that will be written when the write action is performed.
-bytesToWrite :: Write -> BYTES Int
-bytesToWrite = semiRMonoid
+bytesToWrite :: WriteM m -> BYTES Int
+bytesToWrite = semiRMonoid . unWriteM
 
 -- | Perform the write action without any checks.
-unsafeWrite :: Write -> Pointer -> IO ()
-unsafeWrite wr =  unWriteM . semiRSpace wr
+unsafeWrite :: WriteM m -> Pointer -> m ()
+unsafeWrite wr =  unTransferM . semiRSpace (unWriteM wr)
 
 {-
 -- | The function tries to write the given `Write` action on the
 -- buffer and returns `True` if successful.
-tryWriting :: Write         -- ^ The write action.
+tryWriting :: WriteM         -- ^ The write action.
            -> CryptoBuffer  -- ^ The buffer to which the bytes are to
                             -- be written.
            -> IO Bool
 tryWriting wr cbuf = withCryptoBuffer cbuf $ \ sz cptr ->
-  if sz < bytesToWrite wr then return False
+  if sz < bytesToWriteM wr then return False
   else do unsafeWrite wr cptr; return True
 
 -}
+
+
+makeWrite     :: LengthUnit u => u -> (Pointer -> m ()) -> WriteM m
+makeWrite sz  = WriteM . makeTransfer sz
+
 
 -- | The expression @`writeStorable` a@ gives a write action that
 -- stores a value @a@ in machine endian. The type of the value @a@ has
@@ -90,47 +101,58 @@ tryWriting wr cbuf = withCryptoBuffer cbuf $ \ sz cptr ->
 -- to talk with C functions and not when talking to the outside world
 -- (otherwise this could lead to endian confusion). To take care of
 -- endianness use the `write` combinator.
-writeStorable :: Storable a => a -> Write
-writeStorable a = makeWrite (byteSize a) pokeIt
-  where pokeIt = flip poke a . castPtr
+writeStorable :: (MonadIO m, Storable a) => a -> WriteM m
+writeStorable a = WriteM $ makeTransfer (byteSize a) pokeIt
+  where pokeIt = liftIO . flip poke a . castPtr
 -- | The expression @`write` a@ gives a write action that stores a
 -- value @a@. One needs the type of the value @a@ to be an instance of
 -- `EndianStore`. Proper endian conversion is done irrespective of
 -- what the machine endianness is. The man use of this write is to
 -- serialize data for the consumption of the outside world.
-write :: EndianStore a => a -> Write
-write a = makeWrite (byteSize a) $ flip store a
+write :: (MonadIO m, EndianStore a) => a -> WriteM m
+write a = makeWrite (byteSize a) $ liftIO . flip store a
 
 -- | The vector version of `writeStorable`.
-writeStorableVector :: (Storable a, G.Vector v a) => v a -> Write
+writeStorableVector :: (Storable a, G.Vector v a, MonadIO m) => v a -> WriteM m
 {-# INLINE writeStorableVector #-}
 writeStorableVector = G.foldl' foldFunc mempty
   where foldFunc w a =  w <> writeStorable a
 
+{-
+
+TODO: This function can be slow due to the fact that each time we use
+the semi-direct product, we incur a cost due to the lambda being not
+lifted.
+
+-}
+
 -- | The vector version of `write`.
-writeVector :: (EndianStore a, G.Vector v a) => v a -> Write
+writeVector :: (EndianStore a, G.Vector v a, MonadIO m) => v a -> WriteM m
 {-# INLINE writeVector #-}
+{-# TODO: improve this using the fact that the size is known #-}
 writeVector = G.foldl' foldFunc mempty
   where foldFunc w a =  w <> write a
+{- TODO: Same as in writeStorableVector -}
+
 
 -- | The combinator @writeBytes n b@ writes @b@ as the next @n@
 -- consecutive bytes.
-writeBytes :: LengthUnit n => Word8 -> n -> Write
+writeBytes :: (LengthUnit n, MonadIO m) => Word8 -> n -> WriteM m
 writeBytes w8 n = makeWrite n memsetIt
-  where memsetIt cptr = memset cptr w8 n
+  where memsetIt cptr = liftIO $ memset cptr w8 n
 
 -- | Writes a strict bytestring.
-writeByteString :: ByteString -> Write
-writeByteString bs = makeWrite (BU.length bs) $  BU.unsafeCopyToPointer bs
+writeByteString :: MonadIO m => ByteString -> WriteM m
+writeByteString bs = makeWrite (BU.length bs) $ liftIO  . BU.unsafeCopyToPointer bs
 
 -- | A write action that just skips over the given bytes.
-skipWrite :: LengthUnit u => u -> Write
+skipWrite :: (LengthUnit u, Monad m) => u -> WriteM m
 skipWrite = flip makeWrite $ const $ return ()
 
-instance IsString Write where
+instance MonadIO m => IsString (WriteM m)  where
   fromString = writeByteString . fromString
 
-instance Encodable Write where
+instance Encodable (WriteM IO) where
   {-# INLINE toByteString #-}
   toByteString w  = unsafeCreate n $ unsafeWrite w . castPtr
     where BYTES n = bytesToWrite w

--- a/Raaz/Core/Types/Tuple.hs
+++ b/Raaz/Core/Types/Tuple.hs
@@ -33,7 +33,7 @@ import           Prelude hiding              ( length       )
 import Raaz.Core.Types.Copying
 import Raaz.Core.Types.Equality
 import Raaz.Core.Types.Endian
-import Raaz.Core.Write
+import Raaz.Core.Transfer
 import Raaz.Core.Parse.Applicative
 
 -- | Tuples that encode their length in their types. For tuples, we call

--- a/Raaz/Hash/Internal/HMAC.hs
+++ b/Raaz/Hash/Internal/HMAC.hs
@@ -34,7 +34,7 @@ import           System.IO.Unsafe     (unsafePerformIO)
 
 import           Raaz.Core
 import           Raaz.Core.Parse.Applicative
-import           Raaz.Core.Write
+import           Raaz.Core.Transfer
 
 import           Raaz.Hash.Internal
 

--- a/Raaz/Hash/Sha/Util.hs
+++ b/Raaz/Hash/Sha/Util.hs
@@ -32,7 +32,7 @@ shaImplementation :: ( Primitive h
                   => String                   -- ^ Name
                   -> String                   -- ^ Description
                   -> Compressor
-                  -> (BITS Word64 -> Write)
+                  -> (BITS Word64 -> WriteIO)
                   -> HashI h (HashMemory h)
 shaImplementation nam des comp lenW
   = HashI { hashIName        = nam
@@ -48,7 +48,7 @@ portableC :: ( Primitive h
              , Initialisable (HashMemory h) ()
              )
           => Compressor
-          -> (BITS Word64 -> Write)
+          -> (BITS Word64 -> WriteIO)
           -> HashI h (HashMemory h)
 portableC = shaImplementation "portable-c-ffi"
             "Implementation using portable C and Haskell FFI"
@@ -68,7 +68,7 @@ shaCompress comp ptr nblocks = do
 -- | The compressor for the last function.
 shaCompressFinal :: (Primitive h, Storable h)
                   => h
-                  -> (BITS Word64 -> Write) -- ^ the length writer
+                  -> (BITS Word64 -> WriteIO) -- ^ the length writer
                   -> Compressor             -- ^ the raw compressor
                   -> Pointer                -- ^ the buffer
                   -> BYTES Int              -- ^ the message length
@@ -82,19 +82,19 @@ shaCompressFinal h lenW comp ptr nbytes = do
           liftSubMT hashCell $ withPointer $ comp ptr $ fromEnum blocks
 
 -- | The length encoding that uses 64-bits.
-length64Write :: BITS Word64 ->  Write
+length64Write :: BITS Word64 ->  WriteIO
 length64Write (BITS w) = write $ bigEndian w
 
 -- | The length encoding that uses 128-bits.
-length128Write :: BITS Word64 -> Write
+length128Write :: BITS Word64 -> WriteIO
 length128Write w = writeStorable (0 :: Word64) <> length64Write w
 
 -- | The padding to be used
 paddedMesg :: Primitive h
-           => Write        -- ^ The length encoding
+           => WriteIO      -- ^ The length encoding
            -> h            -- ^ The hash
            -> BYTES Int    -- ^ The message length
-           -> Write
+           -> WriteIO
 paddedMesg lenW h msgLen = start <> zeros <> lenW
    where start      = skipWrite msgLen <> writeStorable (0x80 :: Word8)
          zeros      = writeBytes    0    sz

--- a/Raaz/Hash/Sha/Util.hs
+++ b/Raaz/Hash/Sha/Util.hs
@@ -13,7 +13,7 @@ import Data.Word
 import Foreign.Storable
 
 import Raaz.Core
-import Raaz.Core.Write
+import Raaz.Core.Transfer
 import Raaz.Hash.Internal
 
 

--- a/benchmarks/BlazeVsWrite.hs
+++ b/benchmarks/BlazeVsWrite.hs
@@ -14,7 +14,7 @@ import           Data.Word
 import           Foreign.Ptr (castPtr)
 
 import           Raaz.Core.Types
-import qualified Raaz.Core.Write  as RW
+import qualified Raaz.Core.Transfer  as RW
 import qualified Raaz.Core.Encode as E
 
 -- Why 4000 entries. The result size is roughly 32k which is the L1 cache

--- a/benchmarks/BlazeVsWrite.hs
+++ b/benchmarks/BlazeVsWrite.hs
@@ -58,5 +58,5 @@ main = defaultMain
 blazeWrite :: (a -> BB.Write)   -> [a] -> ByteString
 blazeWrite fn = BB.writeToByteString . mconcat . map fn
 
-raazWrite  :: (a -> RW.Write) -> [a] -> ByteString
+raazWrite  :: (a -> RW.WriteIO) -> [a] -> ByteString
 raazWrite fn = E.toByteString . mconcat . map fn

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -71,7 +71,7 @@ library
                  , Raaz.Core.Random
                  , Raaz.Core.Types
                  , Raaz.Core.Util
-                 , Raaz.Core.Write
+                 , Raaz.Core.Transfer
                  --
                  -- Cryptographic hashes
                  --


### PR DESCRIPTION
The `Initialisable` and the `Extractable` class allows memory elements to be initialised by pure values and extract pure values out of memory elements respectively. However pure values are stored in Haskell heap and can get swapped and hence these interfaces are not a good way to initialise or extract sensitive values.

This pull request builds an interface where direct buffer to buffer initialisation/extraction is possible for memory elements. These operations minimise the chances of values escaping into the swap space.