### PR TITLE
explicit import of prelude to fix warnings.

### DIFF
--- a/Raaz/Cipher/AES/CBC/Implementation/CPortable.hs
+++ b/Raaz/Cipher/AES/CBC/Implementation/CPortable.hs
@@ -8,6 +8,8 @@ module Raaz.Cipher.AES.CBC.Implementation.CPortable
 
 import Control.Applicative
 import Control.Monad.IO.Class   ( liftIO )
+import Prelude
+
 import Raaz.Core
 import Raaz.Cipher.Internal
 import Raaz.Cipher.AES.Internal

--- a/Raaz/Core/Encode/Base16.hs
+++ b/Raaz/Core/Encode/Base16.hs
@@ -16,6 +16,9 @@ import Data.ByteString.Internal (c2w )
 import Data.ByteString.Unsafe(unsafeIndex)
 import Data.Monoid
 import Data.Word
+
+import Prelude
+
 import Raaz.Core.Encode.Internal
 
 -- | The type corresponding to base-16 or hexadecimal encoding. The

--- a/Raaz/Core/Primitives.hs
+++ b/Raaz/Core/Primitives.hs
@@ -23,6 +23,7 @@ module Raaz.Core.Primitives
        ) where
 
 import Data.Monoid
+import Prelude
 
 import Raaz.Core.Types
 ----------------------- A primitive ------------------------------------

--- a/Raaz/Core/Random.hs
+++ b/Raaz/Core/Random.hs
@@ -23,6 +23,9 @@ import System.IO ( openBinaryFile, Handle, IOMode(ReadMode)
                  , BufferMode(NoBuffering), hSetBuffering
                  )
 
+
+import Prelude
+
 import Raaz.Core.ByteSource(InfiniteSource, slurpBytes)
 import Raaz.Core.Types
 

--- a/Raaz/Core/Types/Endian.hs
+++ b/Raaz/Core/Types/Endian.hs
@@ -28,6 +28,8 @@ import           Foreign.Ptr                 ( castPtr, Ptr )
 import           Foreign.Storable            ( Storable(..) )
 
 
+import           Prelude
+
 import qualified Data.Vector.Generic         as GV
 import qualified Data.Vector.Generic.Mutable as GVM
 

--- a/Raaz/Core/Types/Pointer.hs
+++ b/Raaz/Core/Types/Pointer.hs
@@ -25,10 +25,8 @@ module Raaz.Core.Types.Pointer
        ) where
 
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative   ( (<$>)   )
-#endif
 
+import Control.Applicative
 import Control.Exception     ( bracket_)
 import Control.Monad         ( void, when )
 import Data.Monoid
@@ -37,6 +35,8 @@ import Foreign.Marshal.Alloc
 import Foreign.Ptr           ( Ptr, plusPtr)
 import Foreign.Storable      (Storable, sizeOf, alignment)
 import System.IO             (hGetBuf, Handle)
+
+import Prelude -- To stop the annoying warnings of Applicatives and Monoids.
 
 import Raaz.Core.MonoidalAction
 import Raaz.Core.Types.Equality

--- a/Raaz/Hash/Sha224/Implementation/CPortable.hs
+++ b/Raaz/Hash/Sha224/Implementation/CPortable.hs
@@ -6,6 +6,8 @@ module Raaz.Hash.Sha224.Implementation.CPortable
        ) where
 
 import Control.Applicative
+import Prelude
+
 import Raaz.Core
 import Raaz.Hash.Internal
 import Raaz.Hash.Sha224.Internal

--- a/Raaz/Hash/Sha384/Implementation/CPortable.hs
+++ b/Raaz/Hash/Sha384/Implementation/CPortable.hs
@@ -6,6 +6,8 @@ module Raaz.Hash.Sha384.Implementation.CPortable
        ) where
 
 import Control.Applicative
+import Prelude
+
 import Raaz.Core
 import Raaz.Hash.Internal
 import Raaz.Hash.Sha384.Internal


### PR DESCRIPTION
this is to fix the irritating warnings due to Applicative and Monoid getting into Prelude.