### PR TITLE
tweaks to the endianness code

### DIFF
--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -2,7 +2,15 @@
 
 /* Include the right header file based on the platform */
 #ifdef __GNUC__
+
+#ifdef PLATFORM_OSX
+#include <libkern/OSByteOrder.h>
+#define bswap_32(a) (OSSwap32(a))
+#define bswap_64(a) (OSSwap64(a))
+#else
 #include <byteswap.h>
+#endif
+
 uint32_t raazSwap32(uint32_t a){ return bswap_32(a);}
 uint64_t raazSwap64(uint64_t a){ return bswap_64(a);}
 

--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -70,8 +70,46 @@ uint64_t raazLoadLE64(uint64_t *ptr)
 # define MOV(a,i)      ((a) << ((i)*8))
 # define SWAP(a,i,j)   (MOV(SEL(a,i),j) | MOV(SEL(a,j),i)) */
 
+#ifdef __GNUC__
+
+#include <byteswap.h>
+
 uint32_t raazSwap32(uint32_t a)
 {
+    return  bswap_32(a);
+}
+
+uint32_t raazSwap64(uint32_t a)
+{
+    return bswap_64(a);
+}
+
+
+void raazSwap32Array(uint32_t *ptr, int n)
+{
+    while(n > 0)
+    {
+	*ptr = bswap_32(*ptr);
+	++ptr; --n;
+    }
+}
+
+void raazSwap64Array(uint64_t *ptr, int n)
+{
+    while( n > 0)
+    {
+
+	*ptr = bswap_64(*ptr);
+	++ptr; --n;
+    }
+}
+
+#else
+
+
+uint32_t raazSwap32(uint32_t a)
+{
+
     return (SWAP(a,0,3) | SWAP(a,1,2));
 }
 
@@ -97,3 +135,6 @@ void raazSwap64Array(uint64_t *ptr, int n)
 	++ptr; --n;
     }
 }
+
+
+#endif

--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -3,8 +3,8 @@
 /* Include the right header file based on the platform */
 #ifdef __GNUC__
 #include <byteswap.h>
-uint32_t raazSwap32(uint32_t a){ return  bswap_32(a);}
-uint32_t raazSwap64(uint32_t a){ return bswap_64(a);}
+uint32_t raazSwap32(uint32_t a){ return bswap_32(a);}
+uint64_t raazSwap64(uint32_t a){ return bswap_64(a);}
 
 void raazSwap32Array(uint32_t *ptr, int n)
 {

--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -1,12 +1,42 @@
 # include <raaz/core/endian.h>
 
 /* Include the right header file based on the platform */
+#ifdef __GNUC__
+#include <byteswap.h>
+uint32_t raazSwap32(uint32_t a){ return  bswap_32(a);}
+uint32_t raazSwap64(uint32_t a){ return bswap_64(a);}
 
-#ifdef PLATFORM_LINUX
-#include <endian.h>
-#elif defined(PLATFORM_BSD) || defined(PLATFORM_OPENBSD)
-#include <sys/endian.h>
+void raazSwap32Array(uint32_t *ptr, int n)
+{
+    for(;n > 0; ++ptr, --n){*ptr = bswap_32(*ptr);}
+}
+
+void raazSwap64Array(uint64_t *ptr, int n)
+{
+    for(;n > 0;++ptr, --n){*ptr = bswap_64(*ptr);}
+}
+
+/*
+
+Endian conversion functions. Note PDP endian architectures are not
+supported.
+
+*/
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+uint32_t raazLoadBE32(uint32_t *wPtr)               { return bswap_32(*wPtr); }
+uint64_t raazLoadBE64(uint64_t *wPtr)               { return bswap_64(*wPtr); }
+uint32_t raazLoadLE32(uint32_t *wPtr)               { return *wPtr; }
+uint64_t raazLoadLE64(uint64_t *wPtr)               { return *wPtr; }
+#else
+uint32_t raazLoadLE32(uint32_t *wPtr)               { return bswap_32(*wPtr); }
+uint64_t raazLoadLE64(uint64_t *wPtr)               { return bswap_64(*wPtr); }
+uint32_t raazLoadBE32(uint32_t *wPtr)               { return *wPtr; }
+uint64_t raazLoadBE64(uint64_t *wPtr)               { return *wPtr; }
 #endif
+
+#else
+
+/* Definitions for portable systems */
 
 # define TO32(w)        ((uint32_t)(w))
 # define TO64(w)        ((uint64_t)(w))
@@ -16,18 +46,8 @@
 # define B(ptr,i) (((unsigned char)(ptr))[(i)])
 # define MK32(a,b,c,d)          ( (a) << 24 | (b) << 16 | (c) << 8 | (d) )
 # define MK64(a,b,c,d,e,f,g,h)  \
-    ((a)   <<  56  | (b) << 48   | (c) << 40 | (d) << 32 \
-     | (e) << 24   | (f) << 16   | (g) << 8  | (h))
+    ((a) <<  56  | (b) << 48   | (c) << 40 | (d) << 32	| (e) << 24   | (f) << 16   | (g) << 8  | (h))
 
-
-#if defined(PLATFORM_LINUX) || defined (PLATFORM_BSD) || defined(PLATFORM_OPENBSD)
-
-    uint32_t raazLoadLE32(uint32_t *wPtr)               { return htole32(*wPtr); }
-    uint32_t raazLoadBE32(uint32_t *wPtr)               { return htobe32(*wPtr); }
-    uint64_t raazLoadLE64(uint64_t *wPtr)               { return htole64(*wPtr); }
-    uint64_t raazLoadBE64(uint64_t *wPtr)               { return htobe64(*wPtr); }
-
-# else /* portable implementation */
 
 uint32_t raazLoadBE32(uint32_t  *ptr)
 {
@@ -54,8 +74,6 @@ uint64_t raazLoadLE64(uint64_t *ptr)
 		B64(ptr,3), B64(ptr,2), B64(ptr,1), B64(ptr,0));
 }
 
-#endif
-
 
 # define MASK(i)       (0xFFULL << (8*(i)))
 # define SEL(a,i)      ((a) & MASK(i))
@@ -65,76 +83,18 @@ uint64_t raazLoadLE64(uint64_t *ptr)
 /* Assuming i < j */
 # define SWAP(a,i,j)   (MOVL(SEL(a,i),(j-i)) | MOVR(SEL(a,j), (j - i)))
 
-/*
-# define SEL(a,i)      ((a) >> (8 * (i)) &  0xFF)
-# define MOV(a,i)      ((a) << ((i)*8))
-# define SWAP(a,i,j)   (MOV(SEL(a,i),j) | MOV(SEL(a,j),i)) */
-
-#ifdef __GNUC__
-
-#include <byteswap.h>
-
-uint32_t raazSwap32(uint32_t a)
-{
-    return  bswap_32(a);
-}
-
-uint32_t raazSwap64(uint32_t a)
-{
-    return bswap_64(a);
-}
+uint32_t raazSwap32(uint32_t a){ return (SWAP(a,0,3) | SWAP(a,1,2)); }
+uint64_t raazSwap64(uint64_t a){ return (SWAP(a,0,7) | SWAP(a,1,6)  | SWAP(a,2,5) | SWAP(a,3,4)); }
 
 
 void raazSwap32Array(uint32_t *ptr, int n)
 {
-    while(n > 0)
-    {
-	*ptr = bswap_32(*ptr);
-	++ptr; --n;
-    }
+    for(;n > 0; ++ptr, --n){*ptr = raazSwap32(*ptr);}
 }
 
 void raazSwap64Array(uint64_t *ptr, int n)
 {
-    while( n > 0)
-    {
-
-	*ptr = bswap_64(*ptr);
-	++ptr; --n;
-    }
+    for(;n > 0; ++ptr, --n){*ptr = raazSwap64(*ptr);}
 }
-
-#else
-
-
-uint32_t raazSwap32(uint32_t a)
-{
-
-    return (SWAP(a,0,3) | SWAP(a,1,2));
-}
-
-uint64_t raazSwap64(uint64_t a)
-{
-    return (SWAP(a,0,7) | SWAP(a,1,6)  | SWAP(a,2,5) | SWAP(a,3,4));
-}
-
-void raazSwap32Array(uint32_t *ptr, int n)
-{
-    while(n > 0)
-    {
-	*ptr = raazSwap32(*ptr);
-	++ptr; --n;
-    }
-}
-
-void raazSwap64Array(uint64_t *ptr, int n)
-{
-    while( n > 0)
-    {
-	*ptr = raazSwap64(*ptr);
-	++ptr; --n;
-    }
-}
-
 
 #endif

--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -4,7 +4,7 @@
 #ifdef __GNUC__
 #include <byteswap.h>
 uint32_t raazSwap32(uint32_t a){ return bswap_32(a);}
-uint64_t raazSwap64(uint32_t a){ return bswap_64(a);}
+uint64_t raazSwap64(uint64_t a){ return bswap_64(a);}
 
 void raazSwap32Array(uint32_t *ptr, int n)
 {

--- a/cbits/raaz/core/endian.c
+++ b/cbits/raaz/core/endian.c
@@ -5,8 +5,8 @@
 
 #ifdef PLATFORM_OSX
 #include <libkern/OSByteOrder.h>
-#define bswap_32(a) (OSSwap32(a))
-#define bswap_64(a) (OSSwap64(a))
+#define bswap_32(a) (OSSwapInt32(a))
+#define bswap_64(a) (OSSwapInt64(a))
 #else
 #include <byteswap.h>
 #endif

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -52,16 +52,6 @@ library
                   -DHAVE_DEV_URANDOM
                   -DHAVE_SYSTEM_PRG
 
-  -- 3. Platform macros for endian conversion functions
-  --
-  if os(linux)
-     cc-options: -DPLATFORM_LINUX
-  if os(freebsd) || os(netbsd)
-     cc-options: -DPLATFORM_BSD
-  if os(openbsd)
-     cc-options: -DPLATFORM_OPENBSD
-
-
   exposed-modules: Raaz
                  , Raaz.Core
                  , Raaz.Core.ByteSource

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -51,6 +51,8 @@ library
      cpp-options: -DHAVE_MLOCK
                   -DHAVE_DEV_URANDOM
                   -DHAVE_SYSTEM_PRG
+  if os(osx)
+     cpp-options: -DPLATFORM_OSX
 
   exposed-modules: Raaz
                  , Raaz.Core

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -52,7 +52,7 @@ library
                   -DHAVE_DEV_URANDOM
                   -DHAVE_SYSTEM_PRG
   if os(osx)
-     cpp-options: -DPLATFORM_OSX
+     cc-options: -DPLATFORM_OSX
 
   exposed-modules: Raaz
                  , Raaz.Core

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -40,14 +40,17 @@ library
   --
   --    * HAVE_DEV_URANDON: If the device /dev/urandom exists.
   --
-  if os(linux) || os(freebsd) || os(openbsd) || os(netbsd) || os(osx)
-     cpp-options: -DHAVE_SYSTEM_PRG
-                  -DHAVE_DEV_URANDOM
+  --
   -- 2. Memory Locking
   --    System supports mlock/munlock calls.
-  -- configurations for memory locking
+  --
+  -- The check below is not really accurate but should work most of
+  -- the time. What I really want is to check if the system is posix.
+  -- TODO: Fix it latter.
   if !os(windows)
      cpp-options: -DHAVE_MLOCK
+                  -DHAVE_DEV_URANDOM
+                  -DHAVE_SYSTEM_PRG
 
   -- 3. Platform macros for endian conversion functions
   --


### PR DESCRIPTION
This pull requests makes the following changes

1. All non-windows platforms are assumed to have /dev/urandom

2. Whenever the underlying C compiler is GCC then use `bswap_32` and
   `bswap_64` from `byteswap.h` for endian conversion and
   adjustments. For all other cases a portable implementation is used.

This pull request is in response to #278.

As a side effect the cabal file has cleaner.
