### PR TITLE
interface to capture alignment restrictions of an implementation

### DIFF
--- a/Raaz/Cipher/AES/CBC/Implementation/CPortable.hs
+++ b/Raaz/Cipher/AES/CBC/Implementation/CPortable.hs
@@ -83,6 +83,7 @@ cbc128CPortable =
             "128-bit AES in cbc mode implemented in Portable C"
           , encryptBlocks = cbc128Encrypt
           , decryptBlocks = cbc128Decrypt
+          , cipherStartAlignment = inBytes (1 :: ALIGN)
           }
 
 -- | The encryption action.
@@ -115,6 +116,7 @@ cbc192CPortable =
             "192-bit AES in cbc mode implemented in Portable C"
           , encryptBlocks = cbc192Encrypt
           , decryptBlocks = cbc192Decrypt
+          , cipherStartAlignment = inBytes (1 :: ALIGN)
           }
 
 -- | The encryption action.
@@ -145,6 +147,8 @@ cbc256CPortable =
             "256-bit AES in cbc mode implemented in Portable C"
           , encryptBlocks = cbc256Encrypt
           , decryptBlocks = cbc256Decrypt
+          , cipherStartAlignment = inBytes (1 :: ALIGN)
+
           }
 
 -- | The encryption action.

--- a/Raaz/Cipher/AES/Internal.hs
+++ b/Raaz/Cipher/AES/Internal.hs
@@ -111,8 +111,7 @@ instance Primitive (AES 128 'CBC) where
   type Implementation (AES 128 'CBC) = SomeCipherI (AES 128 'CBC)
 
 -- | Key is @(`KEY128`,`IV`)@ pair.
-instance Symmetric (AES 128 'CBC) where
-  type Key (AES 128 'CBC) = (KEY128,IV)
+type instance Key (AES 128 'CBC) = (KEY128,IV)
 
 instance Describable (AES 128 'CBC) where
   name _ = "aes-128-cbc"
@@ -132,8 +131,7 @@ instance Primitive (AES 192 'CBC) where
   type Implementation (AES 192 'CBC) = SomeCipherI (AES 192 'CBC)
 
 -- | Key is @(`KEY192`,`IV`)@ pair.
-instance Symmetric (AES 192 'CBC) where
-  type Key (AES 192 'CBC) = (KEY192,IV)
+type instance Key (AES 192 'CBC) = (KEY192,IV)
 
 instance Describable (AES 192 'CBC) where
   name _ = "aes-192-cbc"
@@ -153,8 +151,7 @@ instance Primitive (AES 256 'CBC) where
   type Implementation (AES 256 'CBC) = SomeCipherI (AES 256 'CBC)
 
 -- | Key is @(`KEY256`,`IV`)@ pair.
-instance Symmetric (AES 256 'CBC) where
-  type Key (AES 256 'CBC) = (KEY256,IV)
+type instance Key (AES 256 'CBC) = (KEY256,IV)
 
 
 instance Describable (AES 256 'CBC) where

--- a/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
@@ -36,3 +36,4 @@ chacha20Portable = makeCipherI
                    "chacha20-cportable"
                    "Implementation of the chacha20 stream cipher (RFC7539)"
                    chacha20Block
+                   $ inBytes (1 :: ALIGN)

--- a/Raaz/Cipher/ChaCha20/Implementation/GCCVector.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/GCCVector.hs
@@ -36,3 +36,4 @@ chacha20Vector = makeCipherI
                    "chacha20-gccvector"
                    "Implementation of the chacha20 stream cipher using the gcc's vector instructions"
                    chacha20Block
+                   $ inBytes (1 :: ALIGN) -- ^ TODO improve on this.

--- a/Raaz/Cipher/ChaCha20/Implementation/GCCVector.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/GCCVector.hs
@@ -36,4 +36,4 @@ chacha20Vector = makeCipherI
                    "chacha20-gccvector"
                    "Implementation of the chacha20 stream cipher using the gcc's vector instructions"
                    chacha20Block
-                   $ inBytes (1 :: ALIGN) -- ^ TODO improve on this.
+                   16

--- a/Raaz/Cipher/ChaCha20/Internal.hs
+++ b/Raaz/Cipher/ChaCha20/Internal.hs
@@ -56,8 +56,8 @@ instance Primitive ChaCha20 where
   blockSize _ = BYTES 64
   type Implementation ChaCha20 = SomeCipherI ChaCha20
 
-instance Symmetric ChaCha20 where
-  type Key ChaCha20 = (KEY, IV, Counter)
+-- | The key for ChaCha20.
+type instance Key ChaCha20 = (KEY, IV, Counter)
 
 instance Describable ChaCha20 where
   name        _ = "chacha20"

--- a/Raaz/Core/Primitives.hs
+++ b/Raaz/Core/Primitives.hs
@@ -17,14 +17,44 @@ use a more high level interface.
 
 module Raaz.Core.Primitives
        ( -- * Primtives and their implementations.
-         Primitive(..), Symmetric(..), Asymmetric(..), Recommendation(..)
+         Primitive(..), BlockAlgorithm(..), Symmetric(..), Asymmetric(..), Recommendation(..)
        , BLOCKS, blocksOf
+       , allocBufferFor
        ) where
 
 import Data.Monoid
+import Foreign.Marshal.Alloc
 import Prelude
 
 import Raaz.Core.Types
+
+-- | Implementation of block primitives work on buffers. Often for optimal
+-- performance, and in some case for safety, we need restrictions on
+-- the size and alignment of the buffer pointer. This type class
+-- captures such restrictions.
+class Describable a => BlockAlgorithm a where
+
+  -- | Hints on what sort of alignment is expected for the buffer
+  -- pointer.
+  bufferStartAlignment :: a -> BYTES Int
+
+  -- | The buffer should be a multiple of this size.
+  bufferSizeAlignment  :: a -> BYTES Int
+
+
+
+-- | Allocate a buffer of length at least @l@ suitable for the block
+-- algorithm @algo@. It ensures that the memory passed is aligned
+-- according to the demands of the algorithm.
+allocBufferFor :: (LengthUnit l, BlockAlgorithm algo)
+               => l
+               -> algo
+               -> (Pointer -> IO b)
+               -> IO b
+allocBufferFor l a  = allocaBytesAligned bytes align
+  where BYTES align = bufferStartAlignment a
+        BYTES bytes = alignedToAtleast l $ bufferSizeAlignment a
+
 ----------------------- A primitive ------------------------------------
 
 
@@ -41,7 +71,7 @@ import Raaz.Core.Types
 -- implementation using the `Recommendation` class. By default this is
 -- the implementation used when no explicit implementation is
 -- specified.
-class (Describable (Implementation p)) => Primitive p where
+class (BlockAlgorithm (Implementation p)) => Primitive p where
 
   -- | The block size.
   blockSize :: p -> BYTES Int

--- a/Raaz/Core/Types/Pointer.hs
+++ b/Raaz/Core/Types/Pointer.hs
@@ -18,7 +18,7 @@ module Raaz.Core.Types.Pointer
          -- ** Some length arithmetic
        , bitsQuotRem, bytesQuotRem
        , bitsQuot, bytesQuot
-       , atLeast, atMost
+       , atLeast, atMost, alignedToAtmost, alignedToAtleast
          -- * Helper function that uses generalised length units.
        , allocaBuffer, allocaSecure, mallocBuffer
        , hFillBuf, byteSize
@@ -132,6 +132,24 @@ atMost :: ( LengthUnit src
        => src
        -> dest
 atMost = fst . bytesQuotRem . inBytes
+
+-- | Express the length @l@ in multiples of the
+alignedToAtleast :: LengthUnit l
+                 => l
+                 -> BYTES Int
+                 -> BYTES Int
+alignedToAtleast l b | r == 0    = u       * b
+                     | otherwise = (u + 1) * b
+  where (u,r) = inBytes l `quotRem` b
+
+
+-- | Express the length @l@ in multiples of the
+alignedToAtmost  :: LengthUnit l
+                 => l
+                 -> BYTES Int
+                 -> BYTES Int
+alignedToAtmost l b = inBytes l `quot` b
+
 
 -- | A length unit @u@ is usually a multiple of bytes. The function
 -- `bytesQuotRem` is like `quotRem`: the value @byteQuotRem bytes@ is

--- a/Raaz/Core/Types/Pointer.hs
+++ b/Raaz/Core/Types/Pointer.hs
@@ -18,7 +18,7 @@ module Raaz.Core.Types.Pointer
          -- ** Some length arithmetic
        , bitsQuotRem, bytesQuotRem
        , bitsQuot, bytesQuot
-       , atLeast, atMost, alignedToAtmost, alignedToAtleast
+       , atLeast, atMost
          -- * Helper function that uses generalised length units.
        , allocaBuffer, allocaSecure, mallocBuffer
        , hFillBuf, byteSize
@@ -84,6 +84,7 @@ newtype BITS  a  = BITS  a
         deriving ( Show, Eq, Equality, Ord, Enum, Integral
                  , Real, Num, Storable
                  )
+
 -- | Type safe length unit that measures offsets in multiples of word
 -- length. This length unit can be used if one wants to make sure that
 -- all offsets are word aligned.
@@ -132,24 +133,6 @@ atMost :: ( LengthUnit src
        => src
        -> dest
 atMost = fst . bytesQuotRem . inBytes
-
--- | Express the length @l@ in multiples of the
-alignedToAtleast :: LengthUnit l
-                 => l
-                 -> BYTES Int
-                 -> BYTES Int
-alignedToAtleast l b | r == 0    = u       * b
-                     | otherwise = (u + 1) * b
-  where (u,r) = inBytes l `quotRem` b
-
-
--- | Express the length @l@ in multiples of the
-alignedToAtmost  :: LengthUnit l
-                 => l
-                 -> BYTES Int
-                 -> BYTES Int
-alignedToAtmost l b = inBytes l `quot` b
-
 
 -- | A length unit @u@ is usually a multiple of bytes. The function
 -- `bytesQuotRem` is like `quotRem`: the value @byteQuotRem bytes@ is

--- a/Raaz/Core/Types/Pointer.hs
+++ b/Raaz/Core/Types/Pointer.hs
@@ -218,7 +218,7 @@ byteSize = BYTES . sizeOf
 -- scaling. This function also ensure that the allocated buffer is
 -- word aligned.
 allocaBuffer :: LengthUnit l
-             => l                    -- ^ buffer length
+             => l                  -- ^ buffer length
              -> (Pointer -> IO b)  -- ^ the action to run
              -> IO b
 {-# INLINE allocaBuffer #-}

--- a/Raaz/Hash/Sha/Util.hs
+++ b/Raaz/Hash/Sha/Util.hs
@@ -112,12 +112,11 @@ shaImplementation :: IsSha h
                   -> LengthWrite h
                   -> HashI h (HashMemory h)
 shaImplementation nam des comp lenW
-  = HashI { hashIName        = nam
-          , hashIDescription = des
-          , compress         = shaBlocks shaComp
-          , compressFinal    = shaFinal  shaComp lenW
-          , compressSizeAlignment  = toEnum 1
-          , compressStartAlignment = inBytes (1 :: ALIGN)
+  = HashI { hashIName               = nam
+          , hashIDescription        = des
+          , compress                = shaBlocks shaComp
+          , compressFinal           = shaFinal  shaComp lenW
+          , compressStartAlignment  = inBytes (1 :: ALIGN)
           }
   where shaComp = liftCompressor comp
 

--- a/Raaz/Hash/Sha/Util.hs
+++ b/Raaz/Hash/Sha/Util.hs
@@ -116,6 +116,8 @@ shaImplementation nam des comp lenW
           , hashIDescription = des
           , compress         = shaBlocks shaComp
           , compressFinal    = shaFinal  shaComp lenW
+          , compressSizeAlignment  = toEnum 1
+          , compressStartAlignment = inBytes (1 :: ALIGN)
           }
   where shaComp = liftCompressor comp
 

--- a/cbits/raaz/cipher/chacha20/vector.c
+++ b/cbits/raaz/cipher/chacha20/vector.c
@@ -74,13 +74,12 @@
 # define WRITE(i,R) { MSG  = INP(i); MSG ^= R; INP(i) = MSG; }
 
 /* One should ensure that msg is aligned to 16 bytes. */
-static int chacha20vec128(Block *msg, int nblocks, Key key, IV iv, Counter *ctr)
+static inline void chacha20vec128(Block *msg, int nblocks, const Key key, const IV iv, Counter *ctr)
 {
 
     register Vec A , B, C, D;
     register Vec M1, M2, M3;
     register Vec MSG;
-    int i;
 
     /* TODO: Optimise with vector load (take care of alignments) */
 
@@ -88,7 +87,9 @@ static int chacha20vec128(Block *msg, int nblocks, Key key, IV iv, Counter *ctr)
     M2 =  (Vec){ key[4] , key[5] , key[6] , key[7] };
     M3 =  (Vec){ *(ctr) , iv[0]  ,  iv[1] , iv[2]  };
 
-    while(  nblocks > 0)
+    *ctr += nblocks;
+
+    for(; nblocks > 0; -- nblocks, ++msg)
     {
 	/* Initialise the state;
 	   Except for the counter everything is the same
@@ -122,13 +123,11 @@ static int chacha20vec128(Block *msg, int nblocks, Key key, IV iv, Counter *ctr)
 
 	++M3[0];         /* increment counter      */
 
-	--nblocks; ++msg; /* move to the next block */
-
     }
-    *ctr = M3[0];
+    return;
 }
 
-void raazChaCha20BlockVector(Block *msg, int nblocks, Key key, IV iv, Counter *ctr)
+void raazChaCha20BlockVector(Block *msg, int nblocks, const Key key, const IV iv, Counter *ctr)
 {
     chacha20vec128(msg, nblocks, key, iv, ctr);
 }

--- a/cbits/raaz/cipher/chacha20/vector.c
+++ b/cbits/raaz/cipher/chacha20/vector.c
@@ -67,12 +67,20 @@
 # define XORC(i) (*msg)[i] ^= raaz_tole32( C[i-8]  )
 # define XORD(i) (*msg)[i] ^= raaz_tole32( D[i-12] )
 
+
 # define ChaChaConstantRow  ((Vec){ C0     , C1     , C2     ,  C3    })
+
+# define INP(i) (((Vec *)msg)[i])
+# define WRITE(i,R) { MSG  = INP(i); MSG ^= R; INP(i) = MSG; }
+
+/* One should ensure that msg is aligned to 16 bytes. */
 static int chacha20vec128(Block *msg, int nblocks, Key key, IV iv, Counter *ctr)
 {
 
     register Vec A , B, C, D;
     register Vec M1, M2, M3;
+    register Vec MSG;
+    int i;
 
     /* TODO: Optimise with vector load (take care of alignments) */
 
@@ -109,10 +117,8 @@ static int chacha20vec128(Block *msg, int nblocks, Key key, IV iv, Counter *ctr)
 
 	/* TODO: Optimise with vector load (take care of
 	 * alignments) */
-	XORA(0); XORA(1); XORA(2); XORA(3);
-	XORB(4); XORB(5); XORB(6); XORB(7);
-	XORC(8); XORC(9); XORC(10); XORC(11);
-	XORD(12); XORD(13); XORD(14); XORD(15);
+
+	WRITE(0,A); WRITE(1, B); WRITE(2,C); WRITE(3,D);
 
 	++M3[0];         /* increment counter      */
 


### PR DESCRIPTION
This pull request added support to specify alignment restrictions on buffers used by implementations.
Each implementations now say what kind of alignment is expected out of a buffer unsing the `BufferAlgorithm` class. On the we performed some cleanup.

1. Got rid of the symmetric class
2. Now has a generic funtion to lift buffer allocations inside memory threads.