### PR TITLE
Pay attention to alignments

### DIFF
--- a/Raaz/Cipher/AES/CBC/Implementation/CPortable.hs
+++ b/Raaz/Cipher/AES/CBC/Implementation/CPortable.hs
@@ -83,7 +83,7 @@ cbc128CPortable =
             "128-bit AES in cbc mode implemented in Portable C"
           , encryptBlocks = cbc128Encrypt
           , decryptBlocks = cbc128Decrypt
-          , cipherStartAlignment = inBytes (1 :: ALIGN)
+          , cipherStartAlignment = wordAlignment
           }
 
 -- | The encryption action.
@@ -116,7 +116,7 @@ cbc192CPortable =
             "192-bit AES in cbc mode implemented in Portable C"
           , encryptBlocks = cbc192Encrypt
           , decryptBlocks = cbc192Decrypt
-          , cipherStartAlignment = inBytes (1 :: ALIGN)
+          , cipherStartAlignment = wordAlignment
           }
 
 -- | The encryption action.
@@ -147,7 +147,7 @@ cbc256CPortable =
             "256-bit AES in cbc mode implemented in Portable C"
           , encryptBlocks = cbc256Encrypt
           , decryptBlocks = cbc256Decrypt
-          , cipherStartAlignment = inBytes (1 :: ALIGN)
+          , cipherStartAlignment = wordAlignment
 
           }
 

--- a/Raaz/Cipher/AES/CBC/Implementation/CPortable.hs
+++ b/Raaz/Cipher/AES/CBC/Implementation/CPortable.hs
@@ -23,8 +23,8 @@ data M128 = M128 { m128ekey :: MemoryCell EKEY128
                  }
 
 instance Memory M128  where
-  memoryAlloc   = M128 <$> memoryAlloc <*> memoryAlloc
-  underlyingPtr = underlyingPtr . m128ekey
+  memoryAlloc     = M128 <$> memoryAlloc <*> memoryAlloc
+  unsafeToPointer = unsafeToPointer . m128ekey
 
 instance Initialisable M128 (KEY128, IV) where
   initialise (k,iv) = do
@@ -41,8 +41,8 @@ data M192 = M192 { m192ekey :: MemoryCell EKEY192
                  }
 
 instance Memory M192  where
-  memoryAlloc   = M192 <$> memoryAlloc <*> memoryAlloc
-  underlyingPtr = underlyingPtr . m192ekey
+  memoryAlloc     = M192 <$> memoryAlloc <*> memoryAlloc
+  unsafeToPointer = unsafeToPointer . m192ekey
 
 instance Initialisable M192 (KEY192, IV) where
   initialise (k,iv) = do
@@ -60,8 +60,8 @@ data M256 = M256 { m256ekey :: MemoryCell EKEY256
                  }
 
 instance Memory M256  where
-  memoryAlloc   = M256 <$> memoryAlloc <*> memoryAlloc
-  underlyingPtr = underlyingPtr . m256ekey
+  memoryAlloc     = M256 <$> memoryAlloc <*> memoryAlloc
+  unsafeToPointer = unsafeToPointer . m256ekey
 
 instance Initialisable M256 (KEY256, IV) where
   initialise (k,iv) = do

--- a/Raaz/Cipher/AES/CBC/Implementation/CPortable.hs
+++ b/Raaz/Cipher/AES/CBC/Implementation/CPortable.hs
@@ -8,6 +8,7 @@ module Raaz.Cipher.AES.CBC.Implementation.CPortable
 
 import Control.Applicative
 import Control.Monad.IO.Class   ( liftIO )
+import Foreign.Ptr              ( Ptr    )
 import Prelude
 
 import Raaz.Core
@@ -28,9 +29,9 @@ instance Memory M128  where
 instance Initialisable M128 (KEY128, IV) where
   initialise (k,iv) = do
     onSubMemory m128ekey $ do initialise k
-                              withPointer $ c_transpose 11
+                              withCellPointer $ c_transpose 11
     onSubMemory m128iv   $ do initialise iv
-                              withPointer $ c_transpose 1
+                              withCellPointer $ c_transpose 1
 
 ------------- Memory for 192-bit cbc --------------
 
@@ -46,9 +47,9 @@ instance Memory M192  where
 instance Initialisable M192 (KEY192, IV) where
   initialise (k,iv) = do
     onSubMemory m192ekey $ do initialise k
-                              withPointer $ c_transpose 13
+                              withCellPointer $ c_transpose 13
     onSubMemory m192iv   $ do initialise iv
-                              withPointer $ c_transpose 1
+                              withCellPointer $ c_transpose 1
 
 
 ------------- Memory for 256-bit cbc --------------
@@ -65,9 +66,9 @@ instance Memory M256  where
 instance Initialisable M256 (KEY256, IV) where
   initialise (k,iv) = do
     onSubMemory m256ekey $ do initialise k
-                              withPointer $ c_transpose 15
+                              withCellPointer $ c_transpose 15
     onSubMemory m256iv   $ do initialise iv
-                              withPointer $ c_transpose 1
+                              withCellPointer $ c_transpose 1
 
 ------------------- 128-bit CBC Implementation ----------------
 
@@ -89,15 +90,15 @@ cbc128CPortable =
 -- | The encryption action.
 cbc128Encrypt :: Pointer -> BLOCKS (AES 128 'CBC) -> MT M128 ()
 cbc128Encrypt buf nBlocks =
-  do eKeyPtr <- onSubMemory m128ekey getMemoryPointer
-     ivPtr   <- onSubMemory m128iv   getMemoryPointer
+  do eKeyPtr <- onSubMemory m128ekey getCellPointer
+     ivPtr   <- onSubMemory m128iv   getCellPointer
      liftIO $ c_aes_cbc_e buf (fromEnum nBlocks) 10 eKeyPtr ivPtr
 
 -- | The decryption action.
 cbc128Decrypt :: Pointer -> BLOCKS (AES 128 'CBC) -> MT M128 ()
 cbc128Decrypt buf nBlocks =
-  do eKeyPtr <- onSubMemory m128ekey getMemoryPointer
-     ivPtr   <- onSubMemory m128iv   getMemoryPointer
+  do eKeyPtr <- onSubMemory m128ekey getCellPointer
+     ivPtr   <- onSubMemory m128iv   getCellPointer
      liftIO $ c_aes_cbc_d buf (fromEnum nBlocks) 10 eKeyPtr ivPtr
 
 
@@ -122,15 +123,15 @@ cbc192CPortable =
 -- | The encryption action.
 cbc192Encrypt :: Pointer -> BLOCKS (AES 192 'CBC) -> MT M192 ()
 cbc192Encrypt buf nBlocks =
-  do eKeyPtr <- onSubMemory m192ekey getMemoryPointer
-     ivPtr   <- onSubMemory m192iv   getMemoryPointer
+  do eKeyPtr <- onSubMemory m192ekey getCellPointer
+     ivPtr   <- onSubMemory m192iv   getCellPointer
      liftIO $ c_aes_cbc_e buf (fromEnum nBlocks) 12 eKeyPtr ivPtr
 
 -- | The decryption action.
 cbc192Decrypt :: Pointer -> BLOCKS (AES 192 'CBC) -> MT M192 ()
 cbc192Decrypt buf nBlocks =
-  do eKeyPtr <- onSubMemory m192ekey getMemoryPointer
-     ivPtr   <- onSubMemory m192iv   getMemoryPointer
+  do eKeyPtr <- onSubMemory m192ekey getCellPointer
+     ivPtr   <- onSubMemory m192iv   getCellPointer
      liftIO $ c_aes_cbc_d buf (fromEnum nBlocks) 12 eKeyPtr ivPtr
 
 ------------------- 256-bit CBC Implementation ----------------
@@ -154,15 +155,15 @@ cbc256CPortable =
 -- | The encryption action.
 cbc256Encrypt :: Pointer -> BLOCKS (AES 256 'CBC) -> MT M256 ()
 cbc256Encrypt buf nBlocks =
-  do eKeyPtr <- onSubMemory m256ekey getMemoryPointer
-     ivPtr   <- onSubMemory m256iv   getMemoryPointer
+  do eKeyPtr <- onSubMemory m256ekey getCellPointer
+     ivPtr   <- onSubMemory m256iv   getCellPointer
      liftIO $ c_aes_cbc_e buf (fromEnum nBlocks) 14 eKeyPtr ivPtr
 
 -- | The decryption action.
 cbc256Decrypt :: Pointer -> BLOCKS (AES 256 'CBC) -> MT M256 ()
 cbc256Decrypt buf nBlocks =
-  do eKeyPtr <- onSubMemory m256ekey getMemoryPointer
-     ivPtr   <- onSubMemory m256iv   getMemoryPointer
+  do eKeyPtr <- onSubMemory m256ekey getCellPointer
+     ivPtr   <- onSubMemory m256iv   getCellPointer
      liftIO $ c_aes_cbc_d buf (fromEnum nBlocks) 14 eKeyPtr ivPtr
 
 --------------------- Foreign functions ------------------------
@@ -170,7 +171,7 @@ cbc256Decrypt buf nBlocks =
 -- | Transpose AES matrices.
 foreign import ccall unsafe
   "raaz/cipher/aes/common.h raazAESTranspose"
-  c_transpose :: Int -> Pointer -> IO ()
+  c_transpose :: Int -> Ptr ekey -> IO ()
 
 
 -- | CBC encrypt.
@@ -179,8 +180,8 @@ foreign import ccall unsafe
   c_aes_cbc_e :: Pointer  -- Input
               -> Int      -- number of blocks
               -> Int      -- rounds
-              -> Pointer  -- extended key
-              -> Pointer  -- iv
+              -> Ptr ekey -- extended key
+              -> Ptr iv   -- iv
               -> IO ()
 -- | CBC decrypt
 foreign import ccall unsafe
@@ -188,6 +189,6 @@ foreign import ccall unsafe
   c_aes_cbc_d :: Pointer  -- Input
               -> Int      -- number of blocks
               -> Int      -- rounds
-              -> Pointer  -- extened key
-              -> Pointer  -- iv
+              -> Ptr ekey -- extened key
+              -> Ptr iv  -- iv
               -> IO ()

--- a/Raaz/Cipher/AES/Internal.hs
+++ b/Raaz/Cipher/AES/Internal.hs
@@ -19,7 +19,7 @@ module Raaz.Cipher.AES.Internal
 import Data.String
 import Data.Word
 
-import Foreign.Ptr      (castPtr )
+import Foreign.Ptr      ( castPtr, Ptr )
 import Foreign.Storable (Storable, poke)
 import GHC.TypeLits
 
@@ -174,22 +174,22 @@ newtype EKEY192 = EKEY192 (TUPLE 52) deriving (Storable, EndianStore)
 newtype EKEY256 = EKEY256 (TUPLE 60) deriving (Storable, EndianStore)
 
 instance Initialisable (MemoryCell EKEY128) KEY128 where
-  initialise k = withPointer $ pokeAndExpand k (c_expand 4)
+  initialise k = withCellPointer $ pokeAndExpand k (c_expand 4)
 
 instance Initialisable (MemoryCell EKEY192) KEY192 where
-  initialise k = withPointer $ pokeAndExpand k (c_expand 6)
+  initialise k = withCellPointer $ pokeAndExpand k (c_expand 6)
 
 instance Initialisable (MemoryCell EKEY256) KEY256 where
-  initialise k = withPointer $ pokeAndExpand k (c_expand 8)
+  initialise k = withCellPointer $ pokeAndExpand k (c_expand 8)
 
 foreign import ccall unsafe
   "raaz/cipher/aes/common.h raazAESExpand"
-  c_expand :: Int -> Pointer -> IO ()
+  c_expand :: Int -> Ptr ekey -> IO ()
 
 -- | Poke a key and expand it with the given routine.
 pokeAndExpand :: Storable k
-              => k                   -- ^ key to poke
-              -> (Pointer -> IO ())  -- ^ expansion algorithm
-              -> Pointer             -- ^ buffer pointer.
+              => k                    -- ^ key to poke
+              -> (Ptr ekey -> IO ())  -- ^ expansion algorithm
+              -> Ptr ekey             -- ^ buffer pointer.
               -> IO ()
 pokeAndExpand k expander ptr = poke (castPtr ptr) k >> expander ptr

--- a/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
@@ -36,4 +36,4 @@ chacha20Portable = makeCipherI
                    "chacha20-cportable"
                    "Implementation of the chacha20 stream cipher (RFC7539)"
                    chacha20Block
-                   $ inBytes (1 :: ALIGN)
+                   wordAlignment

--- a/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
@@ -7,6 +7,7 @@ module Raaz.Cipher.ChaCha20.Implementation.CPortable
        ) where
 
 import Control.Monad.IO.Class   ( liftIO )
+import Foreign.Ptr              ( Ptr    )
 
 import Raaz.Core
 import Raaz.Cipher.Internal
@@ -18,17 +19,17 @@ implementation  = SomeCipherI chacha20Portable
 -- | Chacha20 block transformation.
 foreign import ccall unsafe
   "raaz/cipher/chacha20/cportable.h raazChaCha20Block"
-  c_chacha20_block :: Pointer  -- Message
-                   -> Int      -- number of blocks
-                   -> Pointer  -- key
-                   -> Pointer  -- iv
-                   -> Pointer  -- Counter value
+  c_chacha20_block :: Pointer      -- Message
+                   -> Int          -- number of blocks
+                   -> Ptr KEY      -- key
+                   -> Ptr IV       -- iv
+                   -> Ptr Counter  -- Counter value
                    -> IO ()
 
 chacha20Block :: Pointer -> BLOCKS ChaCha20 -> MT ChaCha20Mem ()
-chacha20Block msgPtr nblocks = do keyPtr <- onSubMemory keyCell     getMemoryPointer
-                                  ivPtr  <- onSubMemory ivCell      getMemoryPointer
-                                  ctrPtr <- onSubMemory counterCell getMemoryPointer
+chacha20Block msgPtr nblocks = do keyPtr <- onSubMemory keyCell     getCellPointer
+                                  ivPtr  <- onSubMemory ivCell      getCellPointer
+                                  ctrPtr <- onSubMemory counterCell getCellPointer
                                   liftIO $ c_chacha20_block msgPtr (fromEnum nblocks) keyPtr ivPtr ctrPtr
 
 chacha20Portable :: CipherI ChaCha20 ChaCha20Mem ChaCha20Mem

--- a/Raaz/Cipher/ChaCha20/Implementation/Vector128.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/Vector128.hs
@@ -7,6 +7,7 @@ module Raaz.Cipher.ChaCha20.Implementation.Vector128
        ) where
 
 import Control.Monad.IO.Class   ( liftIO )
+import Foreign.Ptr              ( Ptr    )
 
 import Raaz.Core
 import Raaz.Cipher.Internal
@@ -17,17 +18,17 @@ implementation  = SomeCipherI chacha20Vector
 
 -- | Chacha20 block transformation.
 foreign import ccall unsafe "raazChaCha20BlockVector"
-  c_chacha20_block :: Pointer  -- Message
-                   -> Int      -- number of blocks
-                   -> Pointer  -- key
-                   -> Pointer  -- iv
-                   -> Pointer  -- Counter value
+  c_chacha20_block :: Pointer      -- Message
+                   -> Int          -- number of blocks
+                   -> Ptr KEY      -- key
+                   -> Ptr IV       -- iv
+                   -> Ptr Counter  -- Counter value
                    -> IO ()
 
 chacha20Block :: Pointer -> BLOCKS ChaCha20 -> MT ChaCha20Mem ()
-chacha20Block msgPtr nblocks = do keyPtr <- onSubMemory keyCell     getMemoryPointer
-                                  ivPtr  <- onSubMemory ivCell      getMemoryPointer
-                                  ctrPtr <- onSubMemory counterCell getMemoryPointer
+chacha20Block msgPtr nblocks = do keyPtr <- onSubMemory keyCell     getCellPointer
+                                  ivPtr  <- onSubMemory ivCell      getCellPointer
+                                  ctrPtr <- onSubMemory counterCell getCellPointer
                                   liftIO $ c_chacha20_block msgPtr (fromEnum nblocks) keyPtr ivPtr ctrPtr
 
 chacha20Vector :: CipherI ChaCha20 ChaCha20Mem ChaCha20Mem

--- a/Raaz/Cipher/ChaCha20/Implementation/Vector256.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/Vector256.hs
@@ -6,7 +6,7 @@ module Raaz.Cipher.ChaCha20.Implementation.Vector256
        ) where
 
 import Control.Monad.IO.Class   ( liftIO )
-
+import Foreign.Ptr              ( Ptr    )
 import Raaz.Core
 import Raaz.Cipher.Internal
 import Raaz.Cipher.ChaCha20.Internal
@@ -18,18 +18,18 @@ implementation  = SomeCipherI chacha20Vector
 -- | Chacha20 block transformation.
 foreign import ccall unsafe
   "raazChaCha20BlockVector256"
-  c_chacha20_block :: Pointer  -- Message
-                      -> Int      -- number of blocks
-                      -> Pointer  -- key
-                      -> Pointer  -- iv
-                      -> Pointer  -- Counter value
-                      -> IO ()
+  c_chacha20_block :: Pointer      -- Message
+                   -> Int          -- number of blocks
+                   -> Ptr KEY      -- key
+                   -> Ptr IV       -- iv
+                   -> Ptr Counter  -- Counter value
+                   -> IO ()
 
 
 chacha20Block :: Pointer -> BLOCKS ChaCha20 -> MT ChaCha20Mem ()
-chacha20Block msgPtr nblocks = do keyPtr <- onSubMemory keyCell     getMemoryPointer
-                                  ivPtr  <- onSubMemory ivCell      getMemoryPointer
-                                  ctrPtr <- onSubMemory counterCell getMemoryPointer
+chacha20Block msgPtr nblocks = do keyPtr <- onSubMemory keyCell     getCellPointer
+                                  ivPtr  <- onSubMemory ivCell      getCellPointer
+                                  ctrPtr <- onSubMemory counterCell getCellPointer
                                   liftIO $ c_chacha20_block msgPtr (fromEnum nblocks) keyPtr ivPtr ctrPtr
 
 chacha20Vector :: CipherI ChaCha20 ChaCha20Mem ChaCha20Mem

--- a/Raaz/Cipher/ChaCha20/Internal.hs
+++ b/Raaz/Cipher/ChaCha20/Internal.hs
@@ -78,8 +78,8 @@ data ChaCha20Mem = ChaCha20Mem { keyCell      :: MemoryCell KEY
 
 
 instance Memory ChaCha20Mem where
-  memoryAlloc   = ChaCha20Mem <$> memoryAlloc <*> memoryAlloc <*> memoryAlloc
-  underlyingPtr = underlyingPtr . keyCell
+  memoryAlloc     = ChaCha20Mem <$> memoryAlloc <*> memoryAlloc <*> memoryAlloc
+  unsafeToPointer = unsafeToPointer . keyCell
 
 instance Initialisable ChaCha20Mem (KEY, IV, Counter) where
   initialise (k,iv,ctr) = do onSubMemory keyCell     $ initialise k

--- a/Raaz/Cipher/Internal.hs
+++ b/Raaz/Cipher/Internal.hs
@@ -98,7 +98,7 @@ data CipherI cipher encMem decMem = CipherI
      , encryptBlocks :: Pointer -> BLOCKS cipher -> MT encMem ()
        -- | The underlying block decryption function.
      , decryptBlocks :: Pointer -> BLOCKS cipher -> MT decMem ()
-     , cipherStartAlignment :: BYTES Int
+     , cipherStartAlignment :: Alignment
      }
 
 -- | Type constraints on the memory of a block cipher implementation.
@@ -114,7 +114,7 @@ data SomeCipherI cipher =
   => SomeCipherI (CipherI cipher encMem decMem)
 
 
-instance Primitive cipher => BlockAlgorithm (CipherI cipher encMem decMem) where
+instance BlockAlgorithm (CipherI cipher encMem decMem) where
   bufferStartAlignment = cipherStartAlignment
 
 instance Describable (CipherI cipher encMem decMem) where
@@ -126,7 +126,7 @@ instance Describable (SomeCipherI cipher) where
   name         (SomeCipherI cI) = name cI
   description  (SomeCipherI cI) = description cI
 
-instance Primitive cipher => BlockAlgorithm (SomeCipherI cipher) where
+instance BlockAlgorithm (SomeCipherI cipher) where
   bufferStartAlignment (SomeCipherI imp) = bufferStartAlignment imp
 
 
@@ -159,11 +159,10 @@ class Cipher cipher => StreamCipher cipher
 
 -- | Constructs a `CipherI`  value out of a stream transformation function. Useful in
 --   building a Cipher instance of a stream cipher.
-makeCipherI :: Primitive prim
-            => String                                -- ^ name
+makeCipherI :: String                                -- ^ name
             -> String                                -- ^ description
             -> (Pointer -> BLOCKS prim -> MT mem ()) -- ^ stream transformer
-            -> BYTES Int                             -- ^ buffer starting alignment
+            -> Alignment                             -- ^ buffer starting alignment
             -> CipherI prim mem mem
 makeCipherI nm des trans = CipherI nm des trans trans
 

--- a/Raaz/Core/Encode/Internal.hs
+++ b/Raaz/Core/Encode/Internal.hs
@@ -9,12 +9,11 @@ module Raaz.Core.Encode.Internal
 
 import Data.Maybe
 
-import Data.ByteString              (ByteString)
-import Data.ByteString.Internal     (unsafeCreate)
-import Data.String
-import Data.Word
-import Foreign.Ptr
-import Foreign.Storable
+import           Data.ByteString              (ByteString)
+import           Data.ByteString.Internal     (unsafeCreate)
+import           Data.String
+import           Data.Word
+import           Foreign.Ptr
 import Prelude hiding               (length)
 import System.IO.Unsafe   (unsafePerformIO)
 
@@ -49,12 +48,12 @@ class Encodable a where
   unsafeFromByteString  :: ByteString  -> a
 
   default toByteString :: EndianStore a => a -> ByteString
-  toByteString w    = unsafeCreate (sizeOf w) putit
+  toByteString w    = unsafeCreate (fromEnum $ sizeOf w) putit
     where putit ptr = store (castPtr ptr) w
 
 
   default fromByteString :: EndianStore a => ByteString -> Maybe a
-  fromByteString bs  | byteSize proxy == length bs = Just w
+  fromByteString bs  | sizeOf proxy == length bs   = Just w
                      | otherwise                   = Nothing
          where w     = unsafePerformIO $ withByteString bs (load . castPtr)
                proxy = undefined `asTypeOf` w

--- a/Raaz/Core/Memory.hs
+++ b/Raaz/Core/Memory.hs
@@ -316,32 +316,32 @@ pointerAlloc l = makeAlloc l id
 --
 -- > instance (Memory ma, Memory mb) => Memory (ma, mb) where
 -- >
--- >    memoryAlloc   = (,) <$> memoryAlloc <*> memoryAlloc
+-- >    memoryAlloc             = (,) <$> memoryAlloc <*> memoryAlloc
 -- >
--- >    underlyingPtr (ma, _) =  underlyingPtr ma
+-- >    unsafeToPointer (ma, _) =  unsafeToPointer ma
 --
 class Memory m where
 
   -- | Returns an allocator for this memory.
-  memoryAlloc    :: Alloc m
+  memoryAlloc     :: Alloc m
 
   -- | Returns the pointer to the underlying buffer.
-  underlyingPtr  :: m -> Pointer
+  unsafeToPointer :: m -> Pointer
 
 instance ( Memory ma, Memory mb ) => Memory (ma, mb) where
-    memoryAlloc           = (,) <$> memoryAlloc <*> memoryAlloc
-    underlyingPtr (ma, _) =  underlyingPtr ma
+    memoryAlloc             = (,) <$> memoryAlloc <*> memoryAlloc
+    unsafeToPointer (ma, _) =  unsafeToPointer ma
 
 instance ( Memory ma
          , Memory mb
          , Memory mc
          )
          => Memory (ma, mb, mc) where
-    memoryAlloc           = (,,)
-                            <$> memoryAlloc
-                            <*> memoryAlloc
-                            <*> memoryAlloc
-    underlyingPtr (ma,_,_) =  underlyingPtr ma
+  memoryAlloc              = (,,)
+                             <$> memoryAlloc
+                             <*> memoryAlloc
+                             <*> memoryAlloc
+  unsafeToPointer (ma,_,_) =  unsafeToPointer ma
 
 instance ( Memory ma
          , Memory mb
@@ -349,13 +349,13 @@ instance ( Memory ma
          , Memory md
          )
          => Memory (ma, mb, mc, md) where
-    memoryAlloc           = (,,,)
-                            <$> memoryAlloc
-                            <*> memoryAlloc
-                            <*> memoryAlloc
-                            <*> memoryAlloc
+  memoryAlloc                = (,,,)
+                               <$> memoryAlloc
+                               <*> memoryAlloc
+                               <*> memoryAlloc
+                               <*> memoryAlloc
 
-    underlyingPtr (ma,_,_,_) =  underlyingPtr ma
+  unsafeToPointer (ma,_,_,_) =  unsafeToPointer ma
 
 -- | Copy data from a given memory location to the other. The first
 -- argument is destionation and the second argument is source to match
@@ -363,7 +363,7 @@ instance ( Memory ma
 copyMemory :: Memory m => Dest m -- ^ Destination
                        -> Src  m -- ^ Source
                        -> IO ()
-copyMemory dmem smem = memcpy (underlyingPtr <$> dmem) (underlyingPtr <$> smem) sz
+copyMemory dmem smem = memcpy (unsafeToPointer <$> dmem) (unsafeToPointer <$> smem) sz
   where sz       = twistMonoidValue $ getAlloc smem
         getAlloc :: Memory m => Src m -> Alloc m
         getAlloc _ = memoryAlloc
@@ -454,7 +454,7 @@ instance Storable a => Memory (MemoryCell a) where
     where allocator :: Storable b => b -> Alloc (MemoryCell b)
           allocator b = makeAlloc (alignedSizeOf b) $ MemoryCell . castPtr
 
-  underlyingPtr  = castPtr . unMemoryCell
+  unsafeToPointer  = castPtr . unMemoryCell
 
 -- | The location where the actual storing of element happens. This
 -- pointer is guaranteed to be aligned to the alignment restriction of @a@

--- a/Raaz/Core/Memory.hs
+++ b/Raaz/Core/Memory.hs
@@ -42,7 +42,7 @@ module Raaz.Core.Memory
 
 import           Control.Applicative
 import           Control.Monad.IO.Class
-import           Foreign.Storable            ( Storable(..) )
+import           Foreign.Storable            ( Storable, peek, poke )
 import           Foreign.Ptr                 ( castPtr, Ptr )
 import           Raaz.Core.MonoidalAction
 import           Raaz.Core.Transfer
@@ -463,7 +463,7 @@ instance Storable a => Memory (MemoryCell a) where
 
   memoryAlloc = allocator undefined
     where allocator :: Storable b => b -> Alloc (MemoryCell b)
-          allocator b = makeAlloc (byteSize b) $ MemoryCell . castPtr
+          allocator b = makeAlloc (sizeOf b) $ MemoryCell . castPtr
 
   underlyingPtr  = castPtr . unMemoryCell
 

--- a/Raaz/Core/Memory.hs
+++ b/Raaz/Core/Memory.hs
@@ -297,7 +297,7 @@ type AllocField = Field Pointer
 -- | A memory allocator for the memory type @mem@. The `Applicative`
 -- instance of @Alloc@ can be used to build allocations for
 -- complicated memory elements from simpler ones.
-type Alloc mem = TwistRF AllocField ALIGN mem
+type Alloc mem = TwistRF AllocField (BYTES Int) mem
 
 -- | Make an allocator for a given memory type.
 makeAlloc :: LengthUnit l => l -> (Pointer -> mem) -> Alloc mem

--- a/Raaz/Core/MonoidalAction.hs
+++ b/Raaz/Core/MonoidalAction.hs
@@ -220,7 +220,7 @@ computeField = unwrapArrow
 type FieldM monad = FieldA (Kleisli monad)
 
 -- | Lift a monadic action to FieldM.
-liftToFieldM :: Monad m => (a -> m b) -> FieldM m a b
+liftToFieldM :: (a -> m b) -> FieldM m a b
 liftToFieldM = WrapArrow . Kleisli
 {-# INLINE liftToFieldM #-}
 -- | Runs a monadic field at a given point in the space.

--- a/Raaz/Core/Parse/Applicative.hs
+++ b/Raaz/Core/Parse/Applicative.hs
@@ -61,7 +61,7 @@ undefParse _ = undefined
 -- `Storable` instance.
 parseStorable :: Storable a => Parser a
 parseStorable = pa
-  where pa = makeParser (byteSize $ undefParse pa) (peek . castPtr)
+  where pa = makeParser (sizeOf $ undefParse pa) (peek . castPtr)
 
 -- | Parse a crypto value. Endian safety is take into account
 -- here. This is what you would need when you parse packets from an
@@ -69,7 +69,7 @@ parseStorable = pa
 -- function in a complicated `EndianStore` instance.
 parse :: EndianStore a => Parser a
 parse = pa
-  where pa = makeParser (byteSize $ undefParse pa) (load . castPtr)
+  where pa = makeParser (sizeOf $ undefParse pa) (load . castPtr)
 
 -- | Parses a strict bytestring of a given length.
 parseByteString :: LengthUnit l => l -> Parser ByteString
@@ -82,7 +82,7 @@ parseByteString l = makeParser l $ createFrom l
 unsafeParseStorableVector :: (Storable a, Vector v a) => Int -> Parser (v a)
 unsafeParseStorableVector n = pvec
   where pvec      = makeParser  width $ \ cptr -> generateM n (getA cptr)
-        width     = fromIntegral n * byteSize (undefA pvec)
+        width     = fromIntegral n * sizeOf (undefA pvec)
         undefA    :: (Storable a, Vector v a)=> Parser (v a) -> a
         undefA _  = undefined
         getA      = peekElemOff . castPtr
@@ -94,7 +94,7 @@ unsafeParseStorableVector n = pvec
 unsafeParseVector :: (EndianStore a, Vector v a) => Int -> Parser (v a)
 unsafeParseVector n = pvec
   where pvec     = makeParser  width $ \ cptr -> generateM n (loadFromIndex (castPtr cptr))
-        width    = fromIntegral n * byteSize (undefA pvec)
+        width    = fromIntegral n * sizeOf (undefA pvec)
         undefA   :: (EndianStore a, Vector v a)=> Parser (v a) -> a
         undefA _ = undefined
 

--- a/Raaz/Core/Primitives.hs
+++ b/Raaz/Core/Primitives.hs
@@ -23,7 +23,6 @@ module Raaz.Core.Primitives
        ) where
 
 import Data.Monoid
-import Foreign.Marshal.Alloc
 import Prelude
 
 import Raaz.Core.Types
@@ -35,7 +34,7 @@ import Raaz.Core.Types
 class Describable a => BlockAlgorithm a where
 
   -- | The alignment expected for the buffer pointer.
-  bufferStartAlignment :: a -> BYTES Int
+  bufferStartAlignment :: a -> Alignment
 
 
 ----------------------- A primitive ------------------------------------
@@ -76,9 +75,7 @@ allocBufferFor :: Primitive prim
                -> BLOCKS prim
                -> (Pointer -> IO b)
                -> IO b
-allocBufferFor imp l  = allocaBytesAligned bytes align
-  where BYTES align = bufferStartAlignment imp
-        BYTES bytes = inBytes l
+allocBufferFor imp l  = allocaAligned (bufferStartAlignment imp) l
 
 -- | Some primitives like ciphers have an encryption/decryption key. This
 -- type family captures the key associated with a primitive if it has

--- a/Raaz/Core/Random.hs
+++ b/Raaz/Core/Random.hs
@@ -60,7 +60,7 @@ class Random r where
   default getRandom :: (PRG prg, Storable r) => prg -> IO r
   getRandom = go undefined
     where go       :: (PRG prg, Storable a) => a -> prg -> IO a
-          go w prg = let sz = byteSize w in
+          go w prg = let sz = sizeOf w in
             allocaBuffer sz $ \ ptr -> do
               void $ fillRandomBytes sz ptr prg
               peek $ castPtr ptr

--- a/Raaz/Core/Types/Pointer.hs
+++ b/Raaz/Core/Types/Pointer.hs
@@ -14,7 +14,7 @@ module Raaz.Core.Types.Pointer
          Pointer
          -- ** Type safe length units.
        , LengthUnit(..)
-       , BYTES(..), BITS(..),  ALIGN, Align, inBits
+       , BYTES(..), BITS(..), Alignment, ALIGN, Align, inBits
          -- ** Some length arithmetic
        , bitsQuotRem, bytesQuotRem
        , bitsQuot, bytesQuot
@@ -192,6 +192,16 @@ byteSize = BYTES . sizeOf
 
 
 ------------------------ Allocation --------------------------------
+
+-- | Type safe lengths/offsets in units of bytes.
+newtype Alignment = Alignment Int
+        deriving ( Show, Eq, Ord, Enum, Integral
+                 , Real, Num
+                 )
+
+instance Monoid Alignment where
+  mempty  = Alignment 1
+  mappend = lcm
 
 -- | The expression @allocaBuffer l action@ allocates a local buffer
 -- of length @l@ and passes it on to the IO action @action@. No

--- a/Raaz/Core/Types/Tuple.hs
+++ b/Raaz/Core/Types/Tuple.hs
@@ -142,7 +142,7 @@ unsafeFromList xs
 
 -- | Computes the initial fragment of a tuple. No length needs to be given
 -- as it is infered from the types.
-initial :: (V.Unbox a, Dimension dim0, Dimension dim1)
+initial ::  (V.Unbox a, Dimension dim0)
          => Tuple dim1 a
          -> Tuple dim0 a
 initial tup = tup0

--- a/Raaz/Hash/Internal.hs
+++ b/Raaz/Hash/Internal.hs
@@ -91,7 +91,7 @@ data HashI h m = HashI
                       -- ^ compress the blocks,
   , compressFinal  :: Pointer -> BYTES Int -> MT m ()
                       -- ^ pad and process the final bytes,
-  , compressStartAlignment :: BYTES Int
+  , compressStartAlignment :: Alignment
   }
 
 instance BlockAlgorithm (HashI h m) where

--- a/Raaz/Hash/Internal.hs
+++ b/Raaz/Hash/Internal.hs
@@ -259,9 +259,9 @@ data HashMemory h =
 
 instance Storable h => Memory (HashMemory h) where
 
-  memoryAlloc   = HashMemory <$> memoryAlloc <*> memoryAlloc
+  memoryAlloc     = HashMemory <$> memoryAlloc <*> memoryAlloc
 
-  underlyingPtr = underlyingPtr . hashCell
+  unsafeToPointer = unsafeToPointer . hashCell
 
 instance Storable h => Initialisable (HashMemory h) h where
   initialise h = do

--- a/Raaz/Hash/Internal/HMAC.hs
+++ b/Raaz/Hash/Internal/HMAC.hs
@@ -26,6 +26,7 @@ import qualified Data.ByteString           as B
 import qualified Data.ByteString.Lazy      as L
 import           Data.Monoid
 import           Data.String
+import           Data.Word
 import           Foreign.Ptr               ( castPtr      )
 import           Foreign.Storable          ( Storable(..) )
 import           Prelude                   hiding (length, replicate)
@@ -60,7 +61,7 @@ instance (Hash h, Recommendation h) => Storable (HMACKey h) where
 
   sizeOf    _  = fromIntegral $ blockSize (undefined :: h)
 
-  alignment _  = alignment (undefined :: Align)
+  alignment _  = alignment (undefined :: Word8)
 
   peek         = unsafeRunParser (HMACKey <$> parseByteString (blockSize (undefined :: h))) . castPtr
 

--- a/Raaz/Hash/Internal/HMAC.hs
+++ b/Raaz/Hash/Internal/HMAC.hs
@@ -32,7 +32,7 @@ import           Prelude                   hiding (length, replicate)
 import           System.IO
 import           System.IO.Unsafe     (unsafePerformIO)
 
-import           Raaz.Core
+import           Raaz.Core          hiding (alignment)
 import           Raaz.Core.Parse.Applicative
 import           Raaz.Core.Transfer
 

--- a/Raaz/Hash/Sha/Util.hs
+++ b/Raaz/Hash/Sha/Util.hs
@@ -13,7 +13,7 @@ module Raaz.Hash.Sha.Util
 
 import Data.Monoid                  ( (<>)      )
 import Data.Word
-import Foreign.Storable
+import Foreign.Storable             ( Storable  )
 
 import Raaz.Core
 import Raaz.Core.Transfer
@@ -116,7 +116,7 @@ shaImplementation nam des comp lenW
           , hashIDescription        = des
           , compress                = shaBlocks shaComp
           , compressFinal           = shaFinal  shaComp lenW
-          , compressStartAlignment  = inBytes (1 :: ALIGN)
+          , compressStartAlignment  = wordAlignment
           }
   where shaComp = liftCompressor comp
 

--- a/Raaz/Hash/Sha/Util.hs
+++ b/Raaz/Hash/Sha/Util.hs
@@ -13,6 +13,7 @@ module Raaz.Hash.Sha.Util
 
 import Data.Monoid                  ( (<>)      )
 import Data.Word
+import Foreign.Ptr                  ( Ptr       )
 import Foreign.Storable             ( Storable  )
 
 import Raaz.Core
@@ -50,10 +51,10 @@ length128Write w = writeStorable (0 :: Word64) <> length64Write w
 -- | The type alias for the raw compressor function. The compressor function
 -- does not need to know the length of the message so far and hence
 -- this is not supposed to update lengths.
-type Compressor = Pointer  -- ^ The buffer to compress
-                -> Int     -- ^ The number of blocks to compress
-                -> Pointer -- ^ The cell memory containing the hash
-                -> IO ()
+type Compressor h = Pointer -- ^ The buffer to compress
+                  -> Int    -- ^ The number of blocks to compress
+                  -> Ptr h  -- ^ The cell memory containing the hash
+                  -> IO ()
 
 -- | Action on a Buffer
 type ShaBufferAction bufSize h = Pointer       -- ^ The data buffer
@@ -62,8 +63,8 @@ type ShaBufferAction bufSize h = Pointer       -- ^ The data buffer
 
 -- | Lifts the raw compressor to a buffer action. This function does not update
 -- the lengths.
-liftCompressor          :: IsSha h => Compressor -> ShaBufferAction (BLOCKS h) h
-liftCompressor comp ptr = onSubMemory hashCell . withPointer . comp ptr . fromEnum
+liftCompressor          :: IsSha h => Compressor h -> ShaBufferAction (BLOCKS h) h
+liftCompressor comp ptr = onSubMemory hashCell . withCellPointer . comp ptr . fromEnum
 
 
 -- | The combinator `shaBlocks` on an input compressor @comp@ gives a buffer action
@@ -108,7 +109,7 @@ shaPad h msgLen = glueWrites 0 boundary hdr
 shaImplementation :: IsSha h
                   => String                   -- ^ Name
                   -> String                   -- ^ Description
-                  -> Compressor
+                  -> Compressor  h
                   -> LengthWrite h
                   -> HashI h (HashMemory h)
 shaImplementation nam des comp lenW
@@ -126,7 +127,7 @@ portableC :: ( Primitive h
              , Storable h
              , Initialisable (HashMemory h) ()
              )
-          => Compressor
+          => Compressor  h
           -> LengthWrite h
           -> HashI h (HashMemory h)
 portableC = shaImplementation "portable-c-ffi"

--- a/Raaz/Hash/Sha1/Implementation/CPortable.hs
+++ b/Raaz/Hash/Sha1/Implementation/CPortable.hs
@@ -4,6 +4,7 @@ module Raaz.Hash.Sha1.Implementation.CPortable
        ( implementation
        ) where
 
+import Foreign.Ptr              ( Ptr )
 import Raaz.Core
 import Raaz.Hash.Internal
 import Raaz.Hash.Sha.Util
@@ -18,4 +19,4 @@ cPortable = portableC c_sha1_compress length64Write
 
 foreign import ccall unsafe
   "raaz/hash/sha1/portable.h raazHashSha1PortableCompress"
-  c_sha1_compress  :: Pointer -> Int -> Pointer -> IO ()
+  c_sha1_compress  :: Pointer -> Int -> Ptr SHA1 -> IO ()

--- a/Raaz/Hash/Sha224/Implementation/CPortable.hs
+++ b/Raaz/Hash/Sha224/Implementation/CPortable.hs
@@ -18,8 +18,8 @@ import qualified Raaz.Hash.Sha256.Implementation.CPortable as SHA256I
 newtype SHA224Memory  = SHA224Memory { unSHA224Mem :: HashMemory SHA256 }
 
 instance Memory SHA224Memory where
-  memoryAlloc   = SHA224Memory <$> memoryAlloc
-  underlyingPtr = underlyingPtr . unSHA224Mem
+  memoryAlloc     = SHA224Memory <$> memoryAlloc
+  unsafeToPointer = unsafeToPointer . unSHA224Mem
 
 instance Initialisable SHA224Memory () where
   initialise _ = onSubMemory unSHA224Mem $

--- a/Raaz/Hash/Sha256/Implementation/CPortable.hs
+++ b/Raaz/Hash/Sha256/Implementation/CPortable.hs
@@ -4,6 +4,7 @@ module Raaz.Hash.Sha256.Implementation.CPortable
        ( implementation, cPortable
        ) where
 
+import Foreign.Ptr               ( Ptr )
 import Raaz.Core
 import Raaz.Hash.Internal
 import Raaz.Hash.Sha.Util
@@ -18,4 +19,4 @@ cPortable = portableC c_sha256_compress length64Write
 
 foreign import ccall unsafe
   "raaz/hash/sha256/portable.h raazHashSha256PortableCompress"
-  c_sha256_compress  :: Pointer -> Int -> Pointer -> IO ()
+  c_sha256_compress  :: Pointer -> Int -> Ptr SHA256 -> IO ()

--- a/Raaz/Hash/Sha384/Implementation/CPortable.hs
+++ b/Raaz/Hash/Sha384/Implementation/CPortable.hs
@@ -18,8 +18,8 @@ import qualified Raaz.Hash.Sha512.Implementation.CPortable as SHA512I
 newtype SHA384Memory = SHA384Memory { unSHA384Mem :: HashMemory SHA512 }
 
 instance Memory SHA384Memory where
-  memoryAlloc   = SHA384Memory <$> memoryAlloc
-  underlyingPtr = underlyingPtr . unSHA384Mem
+  memoryAlloc     = SHA384Memory <$> memoryAlloc
+  unsafeToPointer = unsafeToPointer . unSHA384Mem
 
 instance Initialisable SHA384Memory () where
   initialise _ = onSubMemory unSHA384Mem

--- a/Raaz/Hash/Sha512/Implementation/CPortable.hs
+++ b/Raaz/Hash/Sha512/Implementation/CPortable.hs
@@ -4,6 +4,7 @@ module Raaz.Hash.Sha512.Implementation.CPortable
        ( implementation, cPortable
        ) where
 
+import Foreign.Ptr                ( Ptr )
 import Raaz.Core
 import Raaz.Hash.Internal
 import Raaz.Hash.Sha.Util
@@ -18,4 +19,4 @@ cPortable = portableC c_sha512_compress length128Write
 
 foreign import ccall unsafe
   "raaz/hash/sha512/portable.h raazHashSha512PortableCompress"
-  c_sha512_compress  :: Pointer -> Int -> Pointer -> IO ()
+  c_sha512_compress  :: Pointer -> Int -> Ptr SHA512 -> IO ()

--- a/spec/Common/Imports.hs
+++ b/spec/Common/Imports.hs
@@ -7,7 +7,7 @@ import Data.ByteString.Char8        () -- import IsString instance for
 import Data.String             as E
 import Data.Monoid             as E
 import Data.Word               as E
-import Foreign.Storable        as E (Storable(..))
+import Foreign.Storable        as E (Storable, peek, poke)
 import Test.Hspec              as E
 import Test.Hspec.QuickCheck   as E
 import Test.QuickCheck         as E

--- a/spec/Common/Utils.hs
+++ b/spec/Common/Utils.hs
@@ -14,7 +14,7 @@ with key hmsto = hmsto key
 -- | Store and the load the given value.
 storeAndThenLoad :: EndianStore a
                  => a -> IO a
-storeAndThenLoad a = allocaBuffer (byteSize a) (runStoreLoad . castPtr)
+storeAndThenLoad a = allocaBuffer (sizeOf a) (runStoreLoad . castPtr)
   where runStoreLoad ptr = store ptr a >> load ptr
 
 
@@ -28,7 +28,7 @@ storeAdjustAndPeek a
   = allocCast sz $ \ ptr -> do store ptr a
                                adjustEndian ptr 1
                                peek ptr
-  where sz = byteSize a
+  where sz = sizeOf a
 
 pokeAdjustAndLoad :: EndianStore a
                    => a
@@ -37,7 +37,7 @@ pokeAdjustAndLoad a
   = allocCast sz $ \ ptr -> do poke ptr a
                                adjustEndian ptr 1
                                load ptr
-  where sz = byteSize a
+  where sz = sizeOf a
 
 
 
@@ -67,7 +67,7 @@ shortened x | l <= 11    = paddedx
 genEncodable :: (Encodable a, Storable a) => Gen a
 genEncodable = go undefined
   where go :: (Encodable a, Storable a) => a -> Gen a
-        go x = unsafeFromByteString . pack <$> vector (sizeOf x)
+        go x = unsafeFromByteString . pack <$> vector (fromEnum $ sizeOf x)
 
 -- | Generate bytestrings that are multiples of block size of a
 -- primitive.

--- a/spec/Common/Utils.hs
+++ b/spec/Common/Utils.hs
@@ -78,8 +78,7 @@ blocks prim = B.concat <$> listOf singleBlock
 
 
 -- | Run a property with a given generator.
-feed :: (Testable pr, Show a)
-     => Gen a -> (a -> IO pr) -> Property
+feed :: Show a => Gen a -> (a -> IO pr) -> Property
 feed gen pr = monadicIO $ pick gen >>= (run . pr)
 
 repeated :: Monoid m => m -> Int -> m


### PR DESCRIPTION
When peeking/pokeing/loading and storing from pointers, alignment makes or breaks performance.
This series of commits simplify the alignment handling code of raaz. It also adds a separate type
called `Alignment` which _is not_ a length unit but takes care  of alignment.

 