### PR TITLE
Flags to allow GCC to vectorise and nativise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,26 @@
 # Change log for [raaz].
 
-## [0.1.0] - Pending
+## [0.1.0] - 28th February, 2017
 
-- Alignment optimisation for hashing bytestrings (TODO)
-- Num instance from LengthUnit removed Monoid instance added
-  (Commit: 65264e5a89874bab70d0aded3777829209ac5ce2)
+* Stream cipher chacha20 added.
+* Added a PRG that uses chacha20, seeded with system entropy
+* We now have supper command `raaz` with subcommands
+  - `checksum`: as a replacement for the old checksum executable
+  - `rand`: for generating random bytes.
+
+Low level changes
+
+* Reworked alignment considerations.
+
+  - New Alignment type
+
+  - Ways for implementations to demand that the input buffer be aligned
+	(mainly to facilitate more efficient SIMD implementations).
+
+
+* Num instance from LengthUnit removed, Monoid instance added (See
+  issue:#247)
+
 
 ## [0.0.2] - July 25, 2016.
 

--- a/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE DataKinds                        #-}
 
 module Raaz.Cipher.ChaCha20.Implementation.CPortable
-       ( implementation, chacha20Block
+       ( implementation, chacha20Random
        ) where
 
 import Control.Monad.IO.Class   ( liftIO )
@@ -36,6 +36,10 @@ chacha20Block msgPtr nblocks = do keyPtr <- onSubMemory keyCell     getCellPoint
                                   ivPtr  <- onSubMemory ivCell      getCellPointer
                                   ctrPtr <- onSubMemory counterCell getCellPointer
                                   liftIO $ c_chacha20_block msgPtr (fromEnum nblocks) keyPtr ivPtr ctrPtr
+
+-- | The chacha20 randomness generator.
+chacha20Random :: Pointer -> BLOCKS ChaCha20 -> MT ChaCha20Mem ()
+chacha20Random = chacha20Block
 
 chacha20Portable :: CipherI ChaCha20 ChaCha20Mem ChaCha20Mem
 chacha20Portable = makeCipherI

--- a/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
@@ -46,4 +46,4 @@ chacha20Portable = makeCipherI
                    "chacha20-cportable"
                    "Implementation of the chacha20 stream cipher (RFC7539)"
                    chacha20Block
-                   wordAlignment
+                   32

--- a/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/CPortable.hs
@@ -41,6 +41,10 @@ chacha20Block msgPtr nblocks = do keyPtr <- onSubMemory keyCell     getCellPoint
 chacha20Random :: Pointer -> BLOCKS ChaCha20 -> MT ChaCha20Mem ()
 chacha20Random = chacha20Block
 
+---------------------- DANGEROUS CODE --------------------------------------
+
+-- | The chacha20 randomness generator. We have set the alignment to
+-- 32 because this allows gcc to further optimise the implementation.
 chacha20Portable :: CipherI ChaCha20 ChaCha20Mem ChaCha20Mem
 chacha20Portable = makeCipherI
                    "chacha20-cportable"

--- a/Raaz/Cipher/ChaCha20/Implementation/Vector256.hs
+++ b/Raaz/Cipher/ChaCha20/Implementation/Vector256.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE DataKinds                        #-}
 
 module Raaz.Cipher.ChaCha20.Implementation.Vector256
-       ( implementation, chacha20Block
+       ( implementation, chacha20Random
        ) where
 
 import Control.Monad.IO.Class   ( liftIO )
@@ -13,9 +13,20 @@ import Raaz.Core
 import Raaz.Cipher.Internal
 import Raaz.Cipher.ChaCha20.Internal
 
+--------------------------- Setting up the implementation ----------------------------
 
 implementation :: SomeCipherI ChaCha20
 implementation  = SomeCipherI chacha20Vector
+
+
+chacha20Vector :: CipherI ChaCha20 ChaCha20Mem ChaCha20Mem
+chacha20Vector = makeCipherI
+                 "chacha20-vector-256"
+                 "Implementation of the chacha20 stream cipher using the gcc's 256-bit vector instructions"
+                 chacha20Block
+                 32
+
+----------------------------- The block transformation ---------------------------------
 
 -- | Chacha20 block transformation.
 foreign import ccall unsafe
@@ -27,16 +38,14 @@ foreign import ccall unsafe
                    -> Ptr Counter  -- Counter value
                    -> IO ()
 
-
 chacha20Block :: Pointer -> BLOCKS ChaCha20 -> MT ChaCha20Mem ()
 chacha20Block msgPtr nblocks = do keyPtr <- onSubMemory keyCell     getCellPointer
                                   ivPtr  <- onSubMemory ivCell      getCellPointer
                                   ctrPtr <- onSubMemory counterCell getCellPointer
                                   liftIO $ c_chacha20_block msgPtr (fromEnum nblocks) keyPtr ivPtr ctrPtr
 
-chacha20Vector :: CipherI ChaCha20 ChaCha20Mem ChaCha20Mem
-chacha20Vector = makeCipherI
-                 "chacha20-vector-256"
-                 "Implementation of the chacha20 stream cipher using the gcc's 256-bit vector instructions"
-                 chacha20Block
-                 32
+
+----------------------------- The chacha20 stream cipher ----------------------------------
+
+chacha20Random :: Pointer -> BLOCKS ChaCha20 -> MT ChaCha20Mem ()
+chacha20Random = chacha20Block

--- a/Raaz/Cipher/ChaCha20/Recommendation.hs
+++ b/Raaz/Cipher/ChaCha20/Recommendation.hs
@@ -10,7 +10,7 @@
 --
 
 module Raaz.Cipher.ChaCha20.Recommendation
-       ( chacha20Block, RandomBuf, getBufferPointer, randomBufferSize
+       ( chacha20Random, RandomBuf, getBufferPointer, randomBufferSize
        ) where
 
 import Control.Applicative

--- a/Raaz/Cipher/ChaCha20/Recommendation.hs
+++ b/Raaz/Cipher/ChaCha20/Recommendation.hs
@@ -81,4 +81,4 @@ getBufferPointer = actualPtr <$> getMemory
 -- example the Vector256 implementation handles 2-chacha blocks. Set
 -- this quantity to the maximum supported by all implementations.
 randomBufferSize :: BLOCKS ChaCha20
-randomBufferSize = 2  `blocksOf` ChaCha20
+randomBufferSize = 4  `blocksOf` ChaCha20

--- a/Raaz/Cipher/ChaCha20/Recommendation.hs
+++ b/Raaz/Cipher/ChaCha20/Recommendation.hs
@@ -43,14 +43,6 @@ newtype RandomBuf = RandomBuf { unBuf :: Pointer }
 
 
 
--- | Implementations are also designed to work with a specific
--- alignment boundary. Unaligned access can slow down the primitives
--- quite a bit. Set this to the maximum of alignment supported by all
--- implementations
-randomBufferAlignment :: Alignment
-randomBufferAlignment = 32 -- For 256-bit vector instructions.
-
-
 instance Memory RandomBuf where
 
   memoryAlloc     = RandomBuf <$> pointerAlloc sz
@@ -71,8 +63,13 @@ getBufferPointer = actualPtr <$> getMemory
 -- Things to take care in this module
 -- ==================================
 --
--- ENSURE randomBufferSize IS THE MAXIMUM FOR ALL IMPLEMENTATIONS of
--- chacha20 random stream. OTHERWISE BUFFER OVERFLOW.
+-- 1. ENSURE randomBufferSize IS THE MAXIMUM FOR ALL IMPLEMENTATIONS of
+--    chacha20 random stream. OTHERWISE BUFFER OVERFLOW.
+--
+-- 2. Ensure that the alignment requirement is the maximum so that any
+--    implementation can use the same memory.
+
+
 
 
 -- | The size of the buffer in blocks of ChaCha20. While the
@@ -82,3 +79,10 @@ getBufferPointer = actualPtr <$> getMemory
 -- this quantity to the maximum supported by all implementations.
 randomBufferSize :: BLOCKS ChaCha20
 randomBufferSize = 4  `blocksOf` ChaCha20
+
+-- | Implementations are also designed to work with a specific
+-- alignment boundary. Unaligned access can slow down the primitives
+-- quite a bit. Set this to the maximum of alignment supported by all
+-- implementations
+randomBufferAlignment :: Alignment
+randomBufferAlignment = 32 -- For 256-bit vector instructions.

--- a/Raaz/Cipher/ChaCha20/Recommendation.hs
+++ b/Raaz/Cipher/ChaCha20/Recommendation.hs
@@ -25,6 +25,11 @@ import Raaz.Cipher.ChaCha20.Implementation.Vector256
 import Raaz.Cipher.ChaCha20.Implementation.CPortable
 #endif
 
+------------ Setting the recommended implementation -------------------
+
+instance Recommendation ChaCha20 where
+         recommended _ = implementation
+
 
 --------------- Some information used by Raaz/Random/ChaCha20PRG.hs -------------
 
@@ -36,14 +41,6 @@ import Raaz.Cipher.ChaCha20.Implementation.CPortable
 
 newtype RandomBuf = RandomBuf { unBuf :: Pointer }
 
-
--- | The size of the buffer in blocks of ChaCha20. While the
--- implementations should handly any multiple of blocks, often
--- implementations naturally handle some multiple of blocks, for
--- example the Vector256 implementation handles 2-chacha blocks. Set
--- this quantity to the maximum supported by all implementations.
-randomBufferSize :: BLOCKS ChaCha20
-randomBufferSize = 2  `blocksOf` ChaCha20
 
 
 -- | Implementations are also designed to work with a specific
@@ -69,7 +66,19 @@ getBufferPointer = actualPtr <$> getMemory
   where actualPtr = flip alignPtr randomBufferAlignment . unBuf
 
 
------------- Setting the recommended implementation -------------------
+--------------------- DANGEROUS CODE --------------------------------
 
-instance Recommendation ChaCha20 where
-         recommended _ = implementation
+-- Things to take care in this module
+-- ==================================
+--
+-- ENSURE randomBufferSize IS THE MAXIMUM FOR ALL IMPLEMENTATIONS of
+-- chacha20 random stream. OTHERWISE BUFFER OVERFLOW.
+
+
+-- | The size of the buffer in blocks of ChaCha20. While the
+-- implementations should handle any multiple of blocks, often
+-- implementations naturally handle some multiple of blocks, for
+-- example the Vector256 implementation handles 2-chacha blocks. Set
+-- this quantity to the maximum supported by all implementations.
+randomBufferSize :: BLOCKS ChaCha20
+randomBufferSize = 2  `blocksOf` ChaCha20

--- a/Raaz/Hash/Internal.hs
+++ b/Raaz/Hash/Internal.hs
@@ -238,7 +238,7 @@ completeHashing imp@(HashI{..}) src =
     in processChunks comp finish src bufSize ptr
   where bufSize             = atLeast l1Cache + 1
         totalSize           = bufSize + additionalPadBlocks undefined
-        allocate            = liftAllocator $ allocBufferFor (SomeHashI imp) totalSize
+        allocate            = liftPointerAction $ allocBufferFor (SomeHashI imp) totalSize
 
 ----------------------- Hash memory ----------------------------------
 

--- a/Raaz/Hash/Internal/HMAC.hs
+++ b/Raaz/Hash/Internal/HMAC.hs
@@ -211,7 +211,7 @@ hmacSource' imp@(SomeHashI hI) key src =
     -- Finish it with hashing the  hash computed above
     HMAC <$> completeHashing hI (toByteString innerHash)
 
-  where allocate = liftAllocator $ allocBufferFor imp $ 1 `asTypeOf` (theBlock key)
+  where allocate = liftPointerAction $ allocBufferFor imp $ 1 `asTypeOf` (theBlock key)
         innerFirstBlock = B.map (xor 0x36) $ hmacAdjustKey key
         outerFirstBlock = B.map (xor 0x5c) $ hmacAdjustKey key
         theBlock :: Key (HMAC h) -> BLOCKS h

--- a/Raaz/Random.hs
+++ b/Raaz/Random.hs
@@ -16,9 +16,9 @@ module Raaz.Random
 import Control.Applicative
 import Control.Monad
 import Control.Monad.IO.Class
-import Data.ByteString             ( ByteString, pack       )
+import Data.ByteString             ( ByteString             )
 import Data.Int
-import Data.Vector.Unboxed  hiding ( replicateM )
+import Data.Vector.Unboxed  hiding ( replicateM, create     )
 import Data.Word
 
 import Foreign.Ptr      ( Ptr     , castPtr)
@@ -158,7 +158,7 @@ class Random a where
 --
 unsafeStorableRandom :: (Memory mem, Storable a) => RT mem a
 unsafeStorableRandom = RT $ onSubMemory fst retA
-  where retA = liftAllocator alloc $ getIt . castPtr
+  where retA = liftPointerAction alloc $ getIt . castPtr
 
         getIt        :: Storable a => Ptr a -> MT RandomState a
         getIt ptr    = unsafePokeManyRandom 1 ptr >> liftIO (peek ptr)
@@ -172,11 +172,11 @@ unsafeStorableRandom = RT $ onSubMemory fst retA
 
 
 -- | Generate a random byteString.
-randomByteString :: (Memory mem, LengthUnit l)
+
+randomByteString :: LengthUnit l
                  => l
                  -> RT mem ByteString
-randomByteString l = pack <$> replicateM n random
-  where n = fromIntegral $ inBytes l
+randomByteString l = RT $ onSubMemory fst  $ liftPointerAction (create l) $ fillRandomBytesMT l
 
 ------------------------------- Some instances of Random ------------------------
 

--- a/Raaz/Random/ChaCha20PRG.hs
+++ b/Raaz/Random/ChaCha20PRG.hs
@@ -52,7 +52,7 @@ instance Memory RandomState where
 newSample :: MT RandomState ()
 newSample = do setRemainingBytes $ inBytes randomBufferSize
                onSubMemory chacha20State seedIfReq
-               withAuxBuffer $ onSubMemory chacha20State . flip chacha20Block randomBufferSize
+               withAuxBuffer $ onSubMemory chacha20State . flip chacha20Random randomBufferSize
 
 -- | See the PRG from system entropy.
 seed :: MT ChaCha20Mem ()

--- a/Reviewing.md
+++ b/Reviewing.md
@@ -1,6 +1,8 @@
 # Checklist for reviewing code.
 
-## Timing safe equality.
+## Reviewing Haskell code
+
+### Timing safe equality.
 
 All cryptographically sensitive data types should have timing safe
 equality comparison. The class `Equality` is the timing safe
@@ -46,6 +48,19 @@ even if `Foo` and `Bar` have timing safe equality.
 data BadSensitiveType = BadSensitiveType Foo Bar deriving Eq
 
 ```
+
+
+### Dangerous modules
+
+We document here some of the Haskell modules that do dangerous stuff
+so that they can be audited more carefully. The exact dangers are
+documented in the module.
+
+
+1. Raaz.Cipher.ChaCha20.Recommendation.
+
+2. Raaz.Cipher.ChaCha20.Implementation.CPortable
+
 
 ## Reviewing C code.
 
@@ -96,12 +111,22 @@ such low level code, it is better to get familiarised with this
 programming pattern.
 
 
-Dangerous modules
-=================
+## Stuff that effects both C and Haskell.
 
-We document here some of the Haskell modules that do dangerous stuff
-so that they can be audited more carefully. The exact dangers are
-documented in the module.
+## Alignment and restrict for block primitives
 
+GCC can perform brutal optimisations even to Portable C
+implementations if the right argument is qualified with restrict and
+the alignment is matched to the associated vector operations. But these
+features are Dangerous
 
-1. Raaz.Cipher.ChaCha20.Recommendation.
+1. Make sure that the alignment that you provide at the Haskell end
+   when you define the Implementation is the same as (or a multiple
+   of) that at the C side.
+
+2. Since we expect to call these functions as an ffi it is relatively
+   safe to assume that the buffer is not aliased. So restrict can also
+   be given.
+
+Be careful with ChaCha20 implementation where the alignment is also
+used for the PRG buffer (See the dangerous modules subsection).

--- a/Reviewing.md
+++ b/Reviewing.md
@@ -94,3 +94,14 @@ chance of incorrect pointer arithmetic. The bugs are concentrated on
 the definition of the block and word types. So if one is reviewing
 such low level code, it is better to get familiarised with this
 programming pattern.
+
+
+Dangerous modules
+=================
+
+We document here some of the Haskell modules that do dangerous stuff
+so that they can be audited more carefully. The exact dangers are
+documented in the module.
+
+
+1. Raaz.Cipher.ChaCha20.Recommendation.

--- a/benchmarks/BenchPrimitives.hs
+++ b/benchmarks/BenchPrimitives.hs
@@ -63,16 +63,16 @@ pprMeasured :: Measured -> Doc
 pprMeasured (Measured{..}) = vcat
   [ text "time       " <+> eq <+> text (secs tm)
   , text "cycles     " <+> eq <+> double cy
-  , text "rate       " <+> eq <+> double rt  <+> text "(bytes/sec)"
-  , text "secs/byte  " <+> eq <+> double secB
+  , text "rate       " <+> eq <+> text rt   <> text "B/sec"
+  , text "secs/byte  " <+> eq <+> text secB <> text "sec/byte"
   , text "cycles/byte" <+> eq <+> double cycB
   ]
   where tm    = measTime   / fromIntegral nRuns
         cy    = fromIntegral measCycles / fromIntegral nRuns
         bytes = fromIntegral nBytes
-        secB  = tm    / bytes
+        secB  = humaniseTime (tm    / bytes)
         cycB  = cy    / bytes
-        rt    = bytes / tm
+        rt    = humaniseBytes (bytes / tm)
         eq    = text "="
 
 
@@ -145,3 +145,34 @@ runRaazBench (nm, bm) = do
   (memt,x) <- measure bm nRuns
   hPutStrLn stderr $ "done."
   return $ text nm $+$ nest 8 (pprMeasured memt)
+
+-------------------------- Humanise output -----------------------------------
+
+-- | Humanise the name of a byte based unit like G bps etc.
+humaniseBytes :: Double -> String
+humaniseBytes = go 0
+  where  go e x  | x < 102.4 || e  == 5 = show x ++ " " ++ unitPrefix e
+                 | otherwise            = go (e+1) $ x / 1024
+
+-- | Humanise time unit in factions of second.
+humaniseTime :: Double -> String
+humaniseTime  = go 0
+  where go e x | x > 1 || e == -3 = show x ++ " " ++ unitPrefix e
+               | otherwise        = go (e  - 1) (x * 1000)
+
+
+
+-- | @prefix n@ gives proper prefix every 10^{3n} exponent
+unitPrefix :: Int -> String
+unitPrefix ex
+  | ex <  -3   = error "exponent too small name"
+  | ex == -3   = "n"
+  | ex == -2   = "μ"
+  | ex == -1   = "m"
+  | ex == 0    = ""
+  | ex == 1    = "K"
+  | ex == 2    = "M"
+  | ex == 3    = "G"
+  | ex == 4    = "T"
+  | ex == 5    = "P"
+  | otherwise  = error "exponent to large to name"

--- a/cbits/raaz/cipher/chacha20/cportable.c
+++ b/cbits/raaz/cipher/chacha20/cportable.c
@@ -64,8 +64,18 @@ Some function for debugging.
 
 */
 
+# ifdef __GNUC__
 
-void raazChaCha20Block(Block *msg, int nblocks, const Key key, const IV iv, Counter *ctr)
+typedef Block MyBlock __attribute__ ((aligned (32)));
+
+void raazChaCha20Block(MyBlock * restrict msg, int nblocks, const Key key, const IV iv, Counter  *ctr)
+
+# else
+
+void raazChaCha20Block(Block * msg, int nblocks, const Key key, const IV iv, Counter  *ctr)
+
+#endif
+
 {
     register Word x0,  x1,  x2, x3;
     register Word x4,  x5,  x6, x7;

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -38,19 +38,21 @@ source-repository head
 flag vector128
      Description: Make use of vector instructions with size being 128.
      Default: False
+     Manual: True
 
 flag vector256
      Description: Make use of gcc vector instructions with size being 256
      Default: False
+     Manual: True
 
 flag vector512
      Description: Make use of gcc vector instructions with size being 512.
      Default: False
-
+     Manual: True
 flag avx2
      Description: Support avx2 optimisations. Warning: enable only if you are sure of support.
      Default: False
-
+     Manual: True
 ----------------------------- The library -----------------------------------------------------
 
 library

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -35,13 +35,28 @@ source-repository head
 
 ------------------------- Flags -------------------------------------------------------------
 
+flag opt-native
+     Description: Use optimisation for the platform on which it is being built. Do not enable this
+        when cross compiling as it can break the implementation. Also tested only with gcc.
+     Default: False
+     Manual: True
+
+
+flag opt-vectorise
+     Description: Enable vectorisation for gcc. This is not always an optimisation and needs to be benchmarked.
+       Also gains are fairly minimal if you do not use opt-natvive.
+     Default: False
+     Manual: True
+
 flag vector128
-     Description: Make use of vector instructions with size being 128.
+     Description: Make use of vector instructions with size being 128. Do not enable this unless you have reasons
+       to. It is better to use opt-native and opt-vectorise and let gcc have a go at the portable implementation
      Default: False
      Manual: True
 
 flag vector256
-     Description: Make use of gcc vector instructions with size being 256
+     Description: Make use of gcc vector instructions with size being 256. Do not enable this unless you have reasons
+       to. It is better to use opt-native and opt-vectorise and let gcc have a go at the portable implementation.
      Default: False
      Manual: True
 
@@ -167,8 +182,12 @@ library
                   , cbits/raaz/cipher/aes/cportable.h
                   , cbits/raaz/cipher/chacha20/common.h
 
-
   --------------------------- Options for vector instructions ---------------------------------
+  if flag(opt-native)
+    cc-options: -march=native
+
+  if flag(opt-vectorise)
+    cc-options: -ftree-vectorize
 
   if flag(vector128)
      cpp-options: -DHAVE_VECTOR_128
@@ -184,8 +203,9 @@ library
 
   if flag(avx2)
      cpp-options: -DHAVE_VECTOR_256
-     cc-options:  -DHAVE_AVX2 -mavx2 -DHAVE_VECTOR_256
-
+     cc-options:  -DHAVE_AVX2  -DHAVE_VECTOR_256
+     if !flag(opt-native)
+        cc-options: -mavx2
   if flag(vector512)
      cpp-options: -DHAVE_VECTOR_512
      cc-options:  -DHAVE_VECTOR_512

--- a/spec/Raaz/Core/Util/ByteStringSpec.hs
+++ b/spec/Raaz/Core/Util/ByteStringSpec.hs
@@ -1,12 +1,12 @@
 module Raaz.Core.Util.ByteStringSpec where
 
-import Common
-import Prelude hiding (length, take)
-import Data.ByteString.Internal(create, createAndTrim)
-import Data.ByteString as B
-import Foreign.Ptr
+import           Common
+import           Prelude hiding (length, take)
+import           Data.ByteString.Internal(createAndTrim)
+import qualified Data.ByteString as B
+import           Foreign.Ptr
 
-import Raaz.Core as RC
+import           Raaz.Core as RC
 
 
 spec :: Spec
@@ -19,15 +19,14 @@ spec = do context "unsafeCopyToPointer" $
                        return (bs, l)
               in context "unsafeNCopyToPointer"
                  $ it "creates the same prefix of at the input pointer"
-                 $ feed gen $ \ (bs,n) -> (==) (take n bs)
+                 $ feed gen $ \ (bs,n) -> (==) (B.take n bs)
                                           <$> clonePrefix (bs,n)
 
           context "createFrom"
             $ it "reads exactly the same bytes from the byte string pointer"
             $ feed arbitrary $ \ bs -> (==bs) <$> readFrom bs
 
-    where clone bs  = create (B.length bs)
-                      $ RC.unsafeCopyToPointer bs . castPtr
+    where clone bs  = create (length bs) $ RC.unsafeCopyToPointer bs . castPtr
           clonePrefix (bs,n)
             = createAndTrim (B.length bs)
               $ \ cptr -> do RC.unsafeNCopyToPointer (BYTES n) bs

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,8 @@ flags:
   # to be carefully verified. Bad things can happen if the machine
   # does not support the features that you enable here.
   raaz:
+    opt-vectorise: true
+    opt-native: true
     vector128: true  # set if machine has 128-bit vector instructions
     vector256: true  # set if machine has 256-bit vector instructions
     vector512: true  # set if machine has 512-bit vector instructions


### PR DESCRIPTION
It seems that GCC with vectorisation and native extension is able to optimise the portable C implementation
much better than hand written using GCC vector intrinsics. We give flags to enable this.