### PR TITLE
Hide sha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Stream cipher chacha20 added.
 * Added a PRG that uses chacha20, seeded with system entropy
+* Sha1 highly depreciated in view of reported collision.
 * We now have supper command `raaz` with subcommands
   - `checksum`: as a replacement for the old checksum executable
   - `rand`: for generating random bytes.

--- a/Raaz/Hash.hs
+++ b/Raaz/Hash.hs
@@ -19,7 +19,6 @@ module Raaz.Hash
          -- * Exposing individual hashes.
          -- $individualHashes$
 
-       , module Raaz.Hash.Sha1
        , module Raaz.Hash.Sha224
        , module Raaz.Hash.Sha256
        , module Raaz.Hash.Sha384
@@ -29,7 +28,6 @@ module Raaz.Hash
        ) where
 
 -- import Raaz.Hash.Blake256
-import Raaz.Hash.Sha1
 import Raaz.Hash.Sha224
 import Raaz.Hash.Sha256
 import Raaz.Hash.Sha384

--- a/Raaz/Hash.hs
+++ b/Raaz/Hash.hs
@@ -38,6 +38,12 @@ import Raaz.Hash.Internal.HMAC ( HMAC, hmac, hmacFile, hmacSource )
 
 -- $computingHash$
 --
+-- === NOTE: SHA1 is broken.
+--
+-- SHA1 is no more available form this module, its use is highly
+-- depreciated. If you want to use it for transition please import
+-- Raaz.Hash.Sha1 specifically
+
 -- The cryptographic hashes provided by raaz give the following
 -- guarantees:
 --

--- a/Raaz/Hash/Sha1.hs
+++ b/Raaz/Hash/Sha1.hs
@@ -3,11 +3,13 @@
 This module exposes combinators to compute the SHA1 hash and the
 associated HMAC for some common types.
 
+
 -}
 module Raaz.Hash.Sha1
-{-# DEPRECATED "sha1 and its hmac is mostly broken. Avoid if possible" #-}
+{-# DEPRECATED "SHA1 is broken. This module is here only for transition." #-}
        (
-         -- * The SHA1 cryptographic hash
+         -- * The broken SHA1 cryptographic hash.
+         -- $sha1$
          SHA1
        , sha1, sha1File, sha1Source
          -- * HMAC computation using SHA1
@@ -24,8 +26,23 @@ import Raaz.Hash.Internal.HMAC ( hmacSource, hmac, hmacFile, HMAC )
 import Raaz.Hash.Sha1.Internal ( SHA1 )
 import Raaz.Hash.Sha1.Recommendation()
 
+-- $sha1$
+--
+-- We already have a collision for SHA1:
+-- <https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html>
+--
+-- While it does not yet rule out SHA1 for some specific tasks, there
+-- is no reason for its continual usage. This module is present only
+-- to facilitate the transition to a better hash. Use it assuming no
+-- security guarantees. Raaz will not try to optimise the
+-- implementations given here and will remove this module at some
+-- point of time. So do not rely on this for your software.
+--
+--
+--
+
 {-# DEPRECATED sha1, sha1File, sha1Source
-               "SHA1 is almost broken, avoid it as much as possible" #-}
+               "SHA1 is broken. This functions are here only for transition." #-}
 -- | Compute the sha1 hash of an instance of `PureByteSource`. Use
 -- this for computing the sha1 hash of a strict or lazy byte string.
 sha1       :: PureByteSource src => src -> SHA1
@@ -46,7 +63,7 @@ sha1Source = hashSource
 
 
 {-# DEPRECATED hmacSha1, hmacSha1File, hmacSha1Source
-               "SHA1 is almost broken, avoid it for hmac-ing" #-}
+               "SHA1 is broken. This functions are here only for transition." #-}
 
 -- | Compute the message authentication code using hmac-sha1.
 hmacSha1 :: PureByteSource src  => Key (HMAC SHA1) -> src -> HMAC SHA1

--- a/bin/Command/Checksum.lhs
+++ b/bin/Command/Checksum.lhs
@@ -42,7 +42,7 @@ be ignored.
 > import System.Console.GetOpt
 
 > import Raaz     hiding (Result)
-
+> import Raaz.Hash.Sha1
 
 
 Verification Tokens
@@ -103,7 +103,7 @@ support. Existential types comes to the rescue once more.
 Here is the table of algorithms that we support currently.
 
 > algorithms :: [(String, SomeAlgorithm)]
-> algorithms =  [ ("sha1"  , SomeAlgorithm (Algorithm :: Algorithm SHA1)   )
+> algorithms =  [ ("broken-sha1"  , SomeAlgorithm (Algorithm :: Algorithm SHA1)   )
 >               , ("sha256", SomeAlgorithm (Algorithm :: Algorithm SHA256) )
 >               , ("sha512", SomeAlgorithm (Algorithm :: Algorithm SHA512) )
 >               -- Add new algorithms here.
@@ -253,12 +253,12 @@ The default options for the command is as follows.
 > defaultOpts =
 >   Options { optHelp       = False
 >           , optCheck      = False
->           , optAlgo       = Right sha1Algorithm
+>           , optAlgo       = Right sha512Algorithm
 >           , optOkey       = \ fp -> putStrLn (fp ++ ": OK")
 >           , optFailed     = \ fp -> putStrLn (fp ++ ": FAILED")
 >           , optPrintCount = printCount
 >           }
->   where sha1Algorithm = SomeAlgorithm (Algorithm :: Algorithm SHA1)
+>   where sha512Algorithm = SomeAlgorithm (Algorithm :: Algorithm SHA512)
 >         printCount n  = when (n > 0) $ do
 >           putStrLn $ show n ++ " failures."
 >           exitFailure
@@ -276,7 +276,7 @@ summarising the changes to the option set.
 >   , Option ['s'] ["status"]  (NoArg setStatusOnly)
 >     "no output only return status"
 >   , Option ['a'] ["algo"]    (ReqArg setAlgo "HASH")
->     $ "hash algorithm to use " ++ "(" ++ algOpts ++ ")"
+>     $ "hash algorithm to use " ++ "[" ++ algOpts ++ "]. Default sha512"
 >   ]
 >   where setHelp      = Endo $ \ opt -> opt { optHelp    = True }
 >         setCheck     = Endo $ \ opt -> opt { optCheck   = True }
@@ -302,7 +302,7 @@ The usage message for the program.
 > usage errs
 >       | null errs = usageInfo header options
 >       | otherwise = "raaz checksum: " ++ unlines errs ++ usageInfo header options
->   where header ="Usage: raaz checksum [OPTIONS] FILE1 FILE2"
+>   where header ="Usage: raaz checksum [OPTIONS] FILE1 FILE2 ..."
 
 
 Parsing the options.

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -158,7 +158,7 @@ library
                , bytestring                     >= 0.9  &&  < 0.11
                , deepseq                        >= 1.1  &&  < 1.5
                , mtl                            >= 2.1  &&  < 2.3
-               , vector                         >= 0.7.1 && < 0.12
+               , vector                         >= 0.7.1 && < 0.13
   if impl(ghc < 8)
     -- 'transformers' needed for "Control.Monad.IO.Class" only
     -- starting with base-4.9 we don't need 'transformers' anymore

--- a/spec/Common/Imports.hs
+++ b/spec/Common/Imports.hs
@@ -15,5 +15,6 @@ import Test.QuickCheck.Monadic as E
 
 import Raaz.Core               as E hiding ((===), Result)
 import Raaz.Hash               as E
+import Raaz.Hash.Sha1          as E
 import Raaz.Cipher             as E
 import Raaz.Cipher.Internal    as E ( unsafeEncrypt', unsafeDecrypt', transform' )


### PR DESCRIPTION
Apropos https://security.googleblog.com/2017/02/announcing-first-sha1-collision.html make sha1 less visible and more depreciated.