### PR TITLE
Improving the interface to PRG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * system entropy: Experimental support for linux getrandom call
 * removed depreciated `liftSubMT` from Memory.
+* Got rid of the class `MemoryMonad`, instead introduced a more specific
+  `MemoryThread`. This allows to treat monads like `RT mem` much like
+  `MT mem`, including possibility of running an action on a sub-memory.
 
 ## [0.1.1] - 2nd  March, 2017
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Got rid of the class `MemoryMonad`, instead introduced a more specific
   `MemoryThread`. This allows to treat monads like `RT mem` much like
   `MT mem`, including possibility of running an action on a sub-memory.
+* combinator to randomise memory cells.
 
 ## [0.1.1] - 2nd  March, 2017
 

--- a/Raaz/Cipher/AES/Internal.hs
+++ b/Raaz/Cipher/AES/Internal.hs
@@ -56,15 +56,15 @@ instance Encodable KEY128
 instance Encodable KEY192
 instance Encodable KEY256
 
-instance Random KEY128 where
-  random = unsafeStorableRandom
+instance RandomStorable KEY128 where
+  fillRandomElements = unsafeFillRandomElements
 
 
-instance Random KEY192 where
-  random = unsafeStorableRandom
+instance RandomStorable KEY192 where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random KEY256 where
-  random = unsafeStorableRandom
+instance RandomStorable KEY256 where
+  fillRandomElements = unsafeFillRandomElements
 
 -- | Expects in base 16
 instance IsString KEY128 where
@@ -96,8 +96,9 @@ instance Show KEY256 where
 newtype IV  = IV (TUPLE 4) deriving (Storable, EndianStore)
 
 instance Encodable IV
-instance Random IV where
-  random = unsafeStorableRandom
+
+instance RandomStorable IV where
+  fillRandomElements = unsafeFillRandomElements
 
 -- | Expects in base16.
 instance IsString IV where

--- a/Raaz/Core/Memory.hs
+++ b/Raaz/Core/Memory.hs
@@ -20,20 +20,22 @@ module Raaz.Core.Memory
        -- * The Memory subsystem.
        -- $memorysubsystem$
 
-       -- ** Initialisation and Extraction.
-       -- $init-extract$
+       -- ** Memory elements.
          Memory(..), VoidMemory, copyMemory
+       -- *** Initialisation and Extraction.
+       -- $init-extract$
        , Initialisable(..), Extractable(..)
        , InitialisableFromBuffer(..), ExtractableToBuffer(..)
        -- *** A basic memory cell.
        , MemoryCell, withCellPointer, getCellPointer
-       -- *** Actions on memory elements.
-       , MT,  execute, getMemory, onSubMemory, modify
+
+       -- ** Memory threads.
+       , MemoryThread(..), doIO , getMemory, modify, execute
+       , MT
        -- **** Some low level `MT` actions.
 
        , liftPointerAction
-       -- ** Generic memory monads.
-       , MonadMemory(..)
+
        -- ** Memory allocation
        ,  Alloc, pointerAlloc
        ) where
@@ -49,12 +51,16 @@ import           Raaz.Core.Types
 -- $memorysubsystem$
 --
 -- Cryptographic operations often need to keep sensitive information
--- in its memory space. If this memory is swapped out to the disk,
--- this can be dangerous. The primary purpose of the memory subsystem
--- is to provide a way to allocate and manage /secure memory/,
--- i.e. memory that will not be swapped out as long as the memory is
--- used and will be wiped clean after use. There are there important
--- parts to the memory subsystem:
+-- like private keys in its memory space. Such sensitive information
+-- can leak to the external would if the memory where the data is
+-- stored is swapped out to a disk. What makes this particularly
+-- dangerous is that the data can reside on the disk almost
+-- permanently and might even survive when the hardware is
+-- scrapped. The primary purpose of the memory subsystem is to provide
+-- a way to allocate and manage /secure memory/, i.e. memory that will
+-- not be swapped out as long as the memory is used and will be wiped
+-- clean after use. There are there important parts to the memory
+-- subsystem:
 --
 -- [The `Memory` type class:] A memory element is some type that holds
 -- an internal buffer inside it.
@@ -70,15 +76,12 @@ import           Raaz.Core.Types
 -- type from its components in a modular fashion _without_ explicit
 -- size calculation or offset computation.
 --
--- [The `MonadMemory` class:] Instances of this class are actions that
--- use some kind of memory elements inside it. Any such monad can
--- either be run using the combinator `securely` or the combinator
--- `insecurely`. If one use the combinator `securely`, then the
--- allocation of the memory element to be used by the action is done
--- using a locked memory pool which is wiped clean before
--- de-allocation. The types `MT` and `MemoryM` are two instances that
--- we expose from this library.
---
+-- [`MemoryThread`s:] Instances of this class are actions that use
+-- some kind of memory elements inside it. Such a thread can be run
+-- using the combinator `securely` or the combinator `insecurely`. If
+-- one use the combinator `securely`, then the allocation of the
+-- memory element to be used by the action is done using a locked
+-- memory pool which is wiped clean before de-allocation.
 
 -- $init-extract$
 --
@@ -103,113 +106,12 @@ import           Raaz.Core.Types
 -- the chances of inadvertent exposure of sensitive information from
 -- the Haskell heap due to swapping.
 
--- | A class that captures monads that use an internal memory element.
---
--- Any instance of `MonadMemory` can be executed `securely` in which
--- case the allocations for the internal memory is done from a locked
--- pool of memory.  This memory is wiped clean before deallocation.
---
--- Systems often put tight restriction on the amount of memory a
--- process can lock.  Therefore, secure memory is often to be used
--- judiciously. Instances of this class /should/ also implement the
--- the combinator `insecurely` which allocates the internal memory
--- from an unlocked pool.
---
--- This library exposes two instances of `MonadMemory`
---
--- 1. /Memory threads/ captured by the type `MT`, which are a sequence
--- of actions that use the same memory element and
---
--- 2. /Memory actions/ captured by the type `MemoryM`.
---
--- __WARNING:__ Be careful with `liftIO`.
---
--- The rule of thumb to follow is that the action being lifted should
--- itself never unlock any memory. In particular, the following code
--- is bad because the `securely` action unlocks some portion of the
--- memory after @foo@ is executed.
---
--- >
--- >  liftIO $ securely $ foo
--- >
---
--- On the other hand the following code is fine
---
--- >
--- > liftIO $ insecurely $ someMemoryAction
--- >
---
--- Whether an @IO@ action unlocks memory is difficult to keep track
--- of; for all you know, it might be a FFI call that does an
--- @memunlock@.
---
--- As to why this is dangerous, it has got to do with the fact that
--- @mlock@ and @munlock@ do not nest correctly. A single @munlock@ can
--- unlock multiple calls of @mlock@ on the same page.
---
-class (Monad m, MonadIO m) => MonadMemory m where
-  -- | Run a memory action with the internal memory allocated from a
-  -- locked memory buffer. This memory buffer will never be swapped
-  -- out by the operating system and will be wiped clean before
-  -- releasing.
-  --
-  -- Memory locking is an expensive operation and usually there would be
-  -- a limit to how much locked memory can be allocated. Nonetheless,
-  -- actions that work with sensitive information like passwords should
-  -- use this to run an memory action.
-  securely   :: m a -> IO a
-
-
-  -- | Run a memory action with the internal memory used by the action
-  -- being allocated from unlocked memory. Use this function when you
-  -- work with data that is not sensitive to security considerations
-  -- (for example, when you want to verify checksums of files).
-  insecurely :: m a -> IO a
-
 
 -- | An action of type @`MT` mem a@ is an action that uses internally
--- a a single memory object of type @mem@ and returns a result of type
+-- a single memory object of type @mem@ and returns a result of type
 -- @a@. All the actions are performed on a single memory element and
--- hence the side effects persist. It is analogues to the @ST@
--- monad.
+-- hence the side effects persist. It is analogues to the @ST@ monad.
 newtype MT mem a = MT { unMT :: mem -> IO a }
-
-------------- Lifting pointer actions -----------------------------
-
--- | A pointer action inside a monad @m@ is some function that takes a
--- pointer action of type @Pointer -> m a@ and supplies it with an
--- appropriate pointer. In particular, memory allocators are pointer
--- actions.
-type PointerAction m a b = (Pointer -> m a) -> m b
-
--- | An IO allocator can be lifted to the memory thread level as follows.
-liftPointerAction :: PointerAction IO a b -> PointerAction (MT mem) a b
-liftPointerAction allocator mtAction
-  = execute $ \ mem -> allocator (\ ptr -> unMT (mtAction ptr) mem)
-
--- TODO: This is a very general pattern needs more exploration.
-
-
--- | Run a given memory action in the memory thread.
-execute :: (mem -> IO a) -> MT mem a
-{-# INLINE execute #-}
-execute = MT
-
-getMemory :: MT mem mem
-getMemory = execute return
-
--- | The combinator @onSubMemory@ allows us to run a memory action on a
--- sub-memory element. Given a memory element of type @mem@ and a
--- sub-element of type @submem@ which can be obtained from the
--- compound memory element of type @mem@ using the projection @proj@,
--- then @onSubMemory proj@ lifts the a memory thread of the sub
--- element to the compound element.
---
-onSubMemory :: (mem -> submem) -- ^ Projection from the compound element
-                               -- to sub memory element.
-            -> MT submem a     -- ^ Memory thread of the sub-element.
-            -> MT mem    a
-onSubMemory proj mt' = execute $ unMT mt' . proj
 
 
 instance Functor (MT mem) where
@@ -224,13 +126,96 @@ instance Monad (MT mem) where
   ma >>= f  =  MT runIt
     where runIt mem = unMT ma mem >>= \ a -> unMT (f a) mem
 
+-- | __WARNING:__ do not lift a secure memory action.
 instance MonadIO (MT mem) where
   liftIO = MT . const
 
-instance Memory mem => MonadMemory (MT mem) where
+-- | A class that captures abstract "memory threads". A memory thread
+-- can either be run `securely` or `insecurely`. Pure IO actions can
+-- be run inside a memory thread using the @runIO@.  However, the IO
+-- action that is being run /must not/ directly or indirectly run a
+-- `secure` action ever. In particular, the following code is bad.
+--
+-- > -- BAD EXAMPLE: DO NOT USE.
+-- > runIO $ securely $ foo
+-- >
+--
+-- On the other hand the following code is fine
+--
+-- >
+-- > runIO $ insecurely $ someMemoryAction
+-- >
+--
+-- As to why this is dangerous, it has got to do with the fact that
+-- @mlock@ and @munlock@ do not nest correctly. A single @munlock@ can
+-- unlock multiple calls of @mlock@ on the same page.  Whether a given
+-- @IO@ action unlocks memory is difficult to keep track of; for all
+-- you know, it might be a FFI call that does an @memunlock@. Hence,
+-- currently there is no easy way to enforce this.
+--
 
-  securely   = withSecureMemory . unMT
-  insecurely = withMemory       . unMT
+class MemoryThread (mT :: * -> * -> *) where
+  -- | Run a memory action with the internal memory allocated from a
+  -- locked memory buffer. This memory buffer will never be swapped
+  -- out by the operating system and will be wiped clean before
+  -- releasing.
+  --
+  -- Memory locking is an expensive operation and usually there would be
+  -- a limit to how much locked memory can be allocated. Nonetheless,
+  -- actions that work with sensitive information like passwords should
+  -- use this to run an memory action.
+  securely   :: (MemoryThread mT, Memory mem ) => mT mem a -> IO a
+
+  -- | Run a memory action with the internal memory used by the action
+  -- being allocated from unlocked memory. Use this function when you
+  -- work with data that is not sensitive to security considerations
+  -- (for example, when you want to verify checksums of files).
+  insecurely :: (MemoryThread mT, Memory mem ) => mT mem a -> IO a
+
+  -- | Lift an actual memory thread.
+  liftMT :: MT mem a -> mT mem a
+
+
+  -- | Combinator that allows us to run a memory action on a
+  -- sub-memory element. A sub-memory of @submem@ of a memory element
+  -- @mem@ is given by a projection @proj : mem -> submem@. The action
+  -- @onSubMemory proj@ lifts the a memory thread on the sub element
+  -- to the compound element.
+  --
+  onSubMemory :: (mem -> submem) -> mT submem a -> mT mem a
+
+
+instance MemoryThread MT where
+  securely               = withSecureMemory . unMT
+  insecurely             = withMemory . unMT
+  liftMT                 = id
+  onSubMemory proj mtsub = MT $ unMT mtsub . proj
+
+------------- Lifting pointer actions -----------------------------
+
+-- | Run a given memory action in the memory thread.
+execute :: MemoryThread mT => (mem -> IO a) -> mT mem a
+execute = liftMT . MT
+
+
+doIO :: MemoryThread mT => IO a -> mT mem a
+doIO = execute . const
+
+-- | A pointer action inside a monad @m@ is some function that takes a
+-- pointer action of type @Pointer -> m a@ and supplies it with an
+-- appropriate pointer. In particular, memory allocators are pointer
+-- actions.
+type PointerAction m a b = (Pointer -> m a) -> m b
+
+-- | An IO allocator can be lifted to the memory thread level as follows.
+liftPointerAction :: PointerAction IO a b -> PointerAction (MT mem) a b
+liftPointerAction allocator mtAction
+  = execute $ \ mem -> allocator (\ ptr -> unMT (mtAction ptr) mem)
+
+-- TODO: This is a very general pattern needs more exploration.
+
+getMemory :: MemoryThread mT => mT mem mem
+getMemory = execute return
 
 ------------------------ A memory allocator -----------------------
 
@@ -288,6 +273,7 @@ data VoidMemory = VoidMemory { unVoidMemory :: Pointer  }
 instance Memory VoidMemory where
   memoryAlloc      = makeAlloc (0 :: BYTES Int) $ VoidMemory
   unsafeToPointer  = unVoidMemory
+
 
 instance ( Memory ma, Memory mb ) => Memory (ma, mb) where
     memoryAlloc             = (,) <$> memoryAlloc <*> memoryAlloc
@@ -386,8 +372,8 @@ class Memory m => Extractable m v where
 -- > modify f = do b          <- extract
 -- >               initialise $  f b
 --
-modify :: (Initialisable m a, Extractable m b) =>  (b -> a) -> MT m ()
-modify f = extract >>= initialise . f
+modify :: (Initialisable mem a, Extractable mem b, MemoryThread mT ) =>  (b -> a) -> mT mem ()
+modify f = liftMT $ extract >>= initialise . f
 
 -- | A memory type that can be initialised from a pointer buffer. The initialisation performs
 -- a direct copy from the input buffer and hence the chances of the
@@ -400,7 +386,6 @@ class Memory m => InitialisableFromBuffer m where
 -- up in the swap space is minimised.
 class Memory m => ExtractableToBuffer m where
   extractor :: m -> WriteM (MT m)
-
 
 --------------------- Some instances of Memory --------------------
 
@@ -424,15 +409,15 @@ actualCellPtr = nextAlignedPtr . unMemoryCell
 
 -- | Work with the underlying pointer of the memory cell. Useful while
 -- working with ffi functions.
-withCellPointer :: Storable a => (Ptr a -> IO b) -> MT (MemoryCell a) b
+withCellPointer :: (MemoryThread mT, Storable a) => (Ptr a -> IO b) -> mT (MemoryCell a) b
 {-# INLINE withCellPointer #-}
 withCellPointer action = execute $ action . actualCellPtr
 
 
 -- | Get the pointer associated with the given memory cell.
-getCellPointer :: Storable a => MT (MemoryCell a) (Ptr a)
+getCellPointer :: (MemoryThread mT, Storable a) => mT (MemoryCell a) (Ptr a)
 {-# INLINE getCellPointer #-}
-getCellPointer = actualCellPtr <$> getMemory
+getCellPointer = liftMT $ actualCellPtr <$> getMemory
 
 instance Storable a => Initialisable (MemoryCell a) a where
   initialise a = execute $ flip pokeAligned a . unMemoryCell

--- a/Raaz/Hash/Internal/HMAC.hs
+++ b/Raaz/Hash/Internal/HMAC.hs
@@ -88,8 +88,8 @@ instance (Hash h, Recommendation h) => EndianStore (HMACKey h) where
   load             = peek
   adjustEndian _ _ = return ()
 
-instance (Hash h, Recommendation h) => Random (HMACKey h) where
-  random = unsafeStorableRandom
+instance (Hash h, Recommendation h) => RandomStorable (HMACKey h) where
+  fillRandomElements = unsafeFillRandomElements
 
 instance (Hash h, Recommendation h) => Encodable (HMACKey h)
 

--- a/Raaz/Random.hs
+++ b/Raaz/Random.hs
@@ -6,10 +6,9 @@ module Raaz.Random
          RandM, RT, liftMT
        , randomByteString
        -- ** Types that can be generated randomly
-       , Random(..)
+       , RandomStorable(..), unsafeFillRandomElements, random
          -- * Low level access to randomness.
        , fillRandomBytes
-       , unsafeStorableRandom
        , reseed
        ) where
 
@@ -34,10 +33,19 @@ import Raaz.Random.ChaCha20PRG
 --
 -- The raaz library gives a relatively high level interface to
 -- randomness. The monad `RandM` captures a batch of actions that
--- generate/use cryptographically secure random bytes. In particular,
--- you can use the functions `random` and `randomByteString` to
--- actually generate random elements.
+-- generate/use cryptographically secure random bytes. The easiest way
+-- to generate a random element is to use the `random` combinator. If
+-- one is interested in a sequence of random bytes, one can use the
+-- `randomBytestring` combinator.
 --
+-- A more low level interface to cryptographic randomness is through
+-- the buffer filling operations `fillRandomBytes` and
+-- `fillRandomElements`. While not as convenient to use as `random`
+-- and `randomByteString`, and in many ways prone to all the problems
+-- with pointer functions, this should be the method of choice for
+-- generating sensitive data as you can make sure that the data does
+-- not end up on the swap device by using a locked memory for the
+-- buffer.
 --
 -- = Running a random action
 --
@@ -166,9 +174,9 @@ instance Memory mem => MonadMemory (RT mem) where
 -- explicitly seed your generator. The insecurely and securely calls
 -- makes sure that your generator is seed before
 -- starting. Furthermore, the generator also reseeds after every few
--- GB of random bytes generates. Generating random data from the
--- system entropy is usually an order of magnitude slower than using a
--- fast stream cipher. Reseeding often can slow your program
+-- GB of random bytes that it generates. Generating random data from
+-- the system entropy is usually an order of magnitude slower than
+-- using a fast stream cipher. Reseeding often can slow your program
 -- considerably without any additional security advantage.
 --
 reseed :: RT mem ()
@@ -179,47 +187,53 @@ fillRandomBytes :: LengthUnit l => l ->  Pointer -> RT mem ()
 fillRandomBytes l = RT . onSubMemory fst . fillRandomBytesMT l
 
 
--- | Types that can be generated at random. It might appear that all
--- storables should be an instance of this class, after all we know
--- the size of the element why not write that many random bytes. In
--- fact, this module provides an `unsafeStorableRandom` which does
--- exactly that. However, we do not give a blanket definition for all
--- storables because for certain refinements of a given type, like for
--- example, Word8's modulo 10, `unsafeStorableRandom` introduces
--- unacceptable skews.
-class Random a where
+-- | Instances of `Storable` which can be randomly generated. It might
+-- appear that all storables can easily be generated randomly should
+-- be instances of this class, after all we know the size of the
+-- element why not write that many random bytes. In fact, this module
+-- provides an `unsafeFillRandomElements` which does that. However, we
+-- do not give a blanket definition for all storables because for
+-- certain refinements of a given type, like for example, Word8's
+-- modulo 10, `unsafeFillRandomElements` introduces unacceptable
+-- skews.
+class Storable a => RandomStorable a where
+  -- | Fill the buffer with so many random elements of type a.
+  fillRandomElements :: Memory mem
+                     => Int       -- ^ number of elements to fill
+                     -> Ptr a     -- ^ The buffer to fill
+                     -> RT mem ()
 
-  random :: Memory mem => RT mem a
 
--- | Generate a random element. The element picked is
--- crypto-graphically pseudo-random.
---
--- This is a helper function that has been exported to simplify the
--- definition of a `Random` instance for `Storable` types. However,
--- there is a reason why we do not give a blanket instance for all
--- instances `Storable` and why this function is unsafe? This function
--- generates a random element of type @a@ by generating @n@ random
--- bytes where @n@ is the size of the elements of @a@. For instances
--- that range the entire @n@ byte space this is fine. However, if the
--- type is actually a refinement of such a type --- consider for
--- example, @`Word8`@ modulo @10@ -- this function generates an
--- unacceptable skew in the distribution. Hence this function is
--- prefixed unsafe.
---
-unsafeStorableRandom :: (Memory mem, Storable a) => RT mem a
-unsafeStorableRandom = RT $ onSubMemory fst retA
-  where retA = liftPointerAction alloc $ getIt . castPtr
-
-        getIt        :: Storable a => Ptr a -> MT RandomState a
-        getIt ptr    = unsafePokeManyRandom 1 ptr >> liftIO (peek ptr)
-        getElement   :: MT RandomState a -> a
+-- | This is a helper function that has been exported to simplify the
+-- definition of a `RandomStorable` instance for `Storable`
+-- types. However, there is a reason why we do not give a blanket
+-- instance for all instances `Storable` and why this function is
+-- unsafe? This function generates a random element of type @a@ by
+-- generating @n@ random bytes where @n@ is the size of the elements
+-- of @a@. For instances that range the entire @n@ byte space this is
+-- fine. However, if the type is actually a refinement of such a type,
+-- (consider a @`Word8`@ modulo @10@ for example) this function
+-- generates an unacceptable skew in the distribution. Hence this
+-- function is prefixed unsafe.
+unsafeFillRandomElements :: (Memory mem, Storable a) => Int -> Ptr a -> RT mem ()
+unsafeFillRandomElements n ptr = fillRandomBytes totalSz $ castPtr ptr
+  where totalSz = fromIntegral n * sizeOf (getElement ptr)
+        getElement :: Ptr a -> a
         getElement _ = undefined
 
-        algn         = alignment $ getElement retA
-        sz           = sizeOf    $ getElement retA
 
-        alloc        = allocaAligned algn sz
-
+-- | Generate a random element from an instance of a RandomStorable
+-- element.
+random :: (RandomStorable a, Memory mem) => RT mem a
+random = RT $ liftPointerAction alloc (getIt . castPtr)
+  where getIt ptr    = unMT $ fillRandomElements 1 ptr >> liftIO (peek ptr)
+        alloc        :: Storable a => (Pointer -> IO a) -> IO a
+        alloc action = allocaAligned algn sz action
+          where getElement   :: (Pointer -> IO b) -> b
+                getElement _ = undefined
+                thisElement  = getElement action
+                algn         = alignment thisElement
+                sz           = sizeOf    thisElement
 
 -- | Generate a random byteString.
 
@@ -230,74 +244,57 @@ randomByteString l = RT $ onSubMemory fst  $ liftPointerAction (create l) $ fill
 
 ------------------------------- Some instances of Random ------------------------
 
-instance Random Word8 where
-  random = unsafeStorableRandom
+instance RandomStorable Word8 where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random Word16 where
-  random = unsafeStorableRandom
+instance RandomStorable Word16 where
 
-instance Random Word32 where
-  random = unsafeStorableRandom
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random Word64 where
-  random = unsafeStorableRandom
+instance RandomStorable Word32 where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random Word where
-  random = unsafeStorableRandom
+instance RandomStorable Word64 where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random Int8 where
-  random = unsafeStorableRandom
+instance RandomStorable Word where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random Int16 where
-  random = unsafeStorableRandom
+instance RandomStorable Int8 where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random Int32 where
-  random = unsafeStorableRandom
+instance RandomStorable Int16 where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random Int64 where
-  random = unsafeStorableRandom
+instance RandomStorable Int32 where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random Int where
-  random = unsafeStorableRandom
+instance RandomStorable Int64 where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random KEY where
-  random = unsafeStorableRandom
+instance RandomStorable Int where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random IV where
-  random = unsafeStorableRandom
+instance RandomStorable KEY where
+  fillRandomElements = unsafeFillRandomElements
 
+instance RandomStorable IV where
+  fillRandomElements = unsafeFillRandomElements
 
-instance Random w => Random (LE w) where
-  random = littleEndian <$> random
+instance RandomStorable w => RandomStorable (LE w) where
+  fillRandomElements n = fillRandomElements n . lePtrToPtr
+    where lePtrToPtr :: Ptr (LE w) -> Ptr w
+          lePtrToPtr = castPtr
 
-instance Random w => Random (BE w) where
-  random = bigEndian <$> random
+instance RandomStorable w => RandomStorable (BE w) where
+  fillRandomElements n = fillRandomElements n . bePtrToPtr
+    where bePtrToPtr :: Ptr (BE w) -> Ptr w
+          bePtrToPtr = castPtr
 
-instance (Dimension d, Unbox w, Random w) => Random (Tuple d w) where
-  random = repeatM random
-
--------------------------- Now comes the boring tuples -----------------
-
-instance (Random a, Random b) => Random (a,b) where
-  random = (,) <$> random <*> random
-
-instance (Random a, Random b, Random c) => Random (a,b,c) where
-  random = (,,) <$> random <*> random <*> random
-
-instance (Random a, Random b, Random c, Random d) => Random (a,b,c,d) where
-  random = (,,,) <$> random <*> random <*> random <*> random
-
-instance (Random a, Random b, Random c, Random d, Random e) => Random (a,b,c,d,e) where
-  random = (,,,,) <$> random <*> random <*> random <*> random <*> random
-
--- | The action @unsafePokeManyRandom n ptr@ pokes @n@ random elements
--- at the location starting at ptr.  If the underlying type does not
--- saturate its entire binary size (think of say Word8 modulo 5), the
--- distribution of elements can be rather skewed . Hence the prefix
--- unsafe. This function is exported to simplify the definition
--- `Random` instance. Do not use it unwisely.
-unsafePokeManyRandom :: Storable a => Int -> Ptr a -> MT RandomState ()
-unsafePokeManyRandom n ptr = fillRandomBytesMT totalSz $ castPtr ptr
-  where totalSz = fromIntegral n * sizeOf (getElement ptr)
-        getElement :: Ptr a -> a
-        getElement _ = undefined
+instance (Dimension d, Unbox w, RandomStorable w) => RandomStorable (Tuple d w) where
+  fillRandomElements n ptr = fillRandomElements (n * sz) $ tupPtrToPtr ptr
+    where getTuple    :: Dimension d => Ptr (Tuple d w) -> Tuple d w
+          getTuple _  = undefined
+          tupPtrToPtr ::  Ptr (Tuple d w) -> Ptr w
+          tupPtrToPtr = castPtr
+          sz         = dimension $ getTuple ptr

--- a/Raaz/Random.hs
+++ b/Raaz/Random.hs
@@ -94,7 +94,7 @@ import Raaz.Random.ChaCha20PRG
 -- around.
 --
 -- The solution is to use an auxiliary memory element of type `mem` to
--- keep such private information and use the monad`RT mem`. Random
+-- keep such private information and use the monad @`RT` mem@. Random
 -- data can be filled into the memory by using the low level routine
 -- `fillRandomBytes` to fill the memory. Given below is a skeleton for
 -- it.


### PR DESCRIPTION
Random generation now restricted to certain storable types only. This restricted interface is more honest as
PRGs can essentially only generate random bytes and storables are just glorified sequence of bytes.

Reworked  `RT mem` to behave more like `MT mem`, including a more generic `onSubMemory` etc.