### PR TITLE
Hardening of the prg to take care of backward security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   `MemoryThread`. This allows to treat monads like `RT mem` much like
   `MT mem`, including possibility of running an action on a sub-memory.
 * combinator to randomise memory cells.
+* hardened the prg so that a compromise on the current prg state will
+  not expose previously generated data.
 
 ## [0.1.1] - 2nd  March, 2017
 

--- a/Raaz/Cipher/ChaCha20/Recommendation.hs
+++ b/Raaz/Cipher/ChaCha20/Recommendation.hs
@@ -78,7 +78,7 @@ getBufferPointer = actualPtr <$> getMemory
 -- example the Vector256 implementation handles 2-chacha blocks. Set
 -- this quantity to the maximum supported by all implementations.
 randomBufferSize :: BLOCKS ChaCha20
-randomBufferSize = 4  `blocksOf` ChaCha20
+randomBufferSize = 16  `blocksOf` ChaCha20
 
 -- | Implementations are also designed to work with a specific
 -- alignment boundary. Unaligned access can slow down the primitives

--- a/spec/prgquality.sh
+++ b/spec/prgquality.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+stack exec raaz rand | dieharder -a -g 200


### PR DESCRIPTION
Each sampling new updates the key/iv pair so that disclosure of the current state will not compromise
previously generated state. This fixes #314