### PR TITLE
openbsd: entropy use the correct arc4random variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * combinator to randomise memory cells.
 * hardened the prg so that a compromise on the current prg state will
   not expose previously generated data.
+* OpenBSD/NetBSD: fix incorrect arc4random call.
 
 ## [0.1.1] - 2nd  March, 2017
 

--- a/entropy/arc4random/Raaz/Entropy.hs
+++ b/entropy/arc4random/Raaz/Entropy.hs
@@ -7,7 +7,7 @@ import Raaz.Core.Types
 
 -- | The getrandom system call.
 foreign import ccall unsafe
-  "arc4random"
+  "arc4random_buf"
   c_arc4random :: Pointer      -- Message
                -> BYTES Int    -- number of bytes
                -> IO (BYTES Int)

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -227,7 +227,7 @@ library
 
      --------------------- Entropy ----------------------------------------------
 
-     if os(openbsd)
+     if os(openbsd) || os(netbsd)
         -- Entropy for openbsd using arc4random
         hs-source-dirs: entropy/arc4random
      else


### PR DESCRIPTION
- Should use arc4random_buf instead of arc4random