### PR TITLE
Remove block num

### DIFF
--- a/Raaz/Core/Primitives.hs
+++ b/Raaz/Core/Primitives.hs
@@ -91,7 +91,7 @@ type family  Key prim :: *
 -- long as they can be converted to bytes. This can avoid a lot of
 -- tedious and error prone length calculations.
 newtype BLOCKS p = BLOCKS {unBLOCKS :: Int}
-                 deriving (Show, Eq, Ord, Enum, Real, Num, Integral)
+                 deriving (Show, Eq, Ord, Enum)
 
 instance Monoid (BLOCKS p) where
   mempty      = BLOCKS 0

--- a/Raaz/Hash/Internal.hs
+++ b/Raaz/Hash/Internal.hs
@@ -36,6 +36,7 @@ import           Control.Applicative
 
 import qualified Data.ByteString      as B
 import qualified Data.ByteString.Lazy as L
+import           Data.Monoid
 import           Data.Word
 import           Foreign.Storable
 import           System.IO
@@ -236,8 +237,8 @@ completeHashing imp@(HashI{..}) src =
     comp                = compress ptr bufSize
     finish bytes        = compressFinal ptr bytes >> extract
     in processChunks comp finish src bufSize ptr
-  where bufSize             = atLeast l1Cache + 1
-        totalSize           = bufSize + additionalPadBlocks undefined
+  where bufSize             = atLeast l1Cache <> toEnum 1
+        totalSize           = bufSize <> additionalPadBlocks undefined
         allocate            = liftPointerAction $ allocBufferFor (SomeHashI imp) totalSize
 
 ----------------------- Hash memory ----------------------------------

--- a/Raaz/Hash/Internal/HMAC.hs
+++ b/Raaz/Hash/Internal/HMAC.hs
@@ -196,7 +196,7 @@ hmacSource' imp@(SomeHashI hI) key src =
     initialise ()
     allocate $ \ ptr -> do
       liftIO $ unsafeCopyToPointer innerFirstBlock ptr
-      compress hI ptr 1
+      compress hI ptr $ toEnum 1
 
     -- Finish it by hashing the source.
     innerHash <- completeHashing hI src
@@ -206,12 +206,12 @@ hmacSource' imp@(SomeHashI hI) key src =
     initialise ()
     allocate $ \ ptr -> do
       liftIO $ unsafeCopyToPointer outerFirstBlock ptr
-      compress hI ptr 1
+      compress hI ptr $ toEnum 1
 
     -- Finish it with hashing the  hash computed above
     HMAC <$> completeHashing hI (toByteString innerHash)
 
-  where allocate = liftPointerAction $ allocBufferFor imp $ 1 `asTypeOf` (theBlock key)
+  where allocate = liftPointerAction $ allocBufferFor imp $ (toEnum 1) `asTypeOf` (theBlock key)
         innerFirstBlock = B.map (xor 0x36) $ hmacAdjustKey key
         outerFirstBlock = B.map (xor 0x5c) $ hmacAdjustKey key
         theBlock :: Key (HMAC h) -> BLOCKS h

--- a/Raaz/Hash/Sha1/Internal.hs
+++ b/Raaz/Hash/Sha1/Internal.hs
@@ -53,4 +53,4 @@ instance Primitive SHA1 where
   type Implementation SHA1 = SomeHashI SHA1
 
 instance Hash SHA1 where
-  additionalPadBlocks _ = 1
+  additionalPadBlocks _ = toEnum 1

--- a/Raaz/Hash/Sha224/Implementation/CPortable.hs
+++ b/Raaz/Hash/Sha224/Implementation/CPortable.hs
@@ -42,4 +42,4 @@ implementation :: Implementation SHA224
 implementation =  SomeHashI cPortable
 
 cPortable :: HashI SHA224 SHA224Memory
-cPortable = truncatedI fromIntegral unSHA224Mem SHA256I.cPortable
+cPortable = truncatedI (toEnum . fromEnum) unSHA224Mem SHA256I.cPortable

--- a/Raaz/Hash/Sha224/Internal.hs
+++ b/Raaz/Hash/Sha224/Internal.hs
@@ -46,4 +46,4 @@ instance Primitive SHA224 where
   type Implementation SHA224 = SomeHashI SHA224
 
 instance Hash SHA224 where
-  additionalPadBlocks _ = 1
+  additionalPadBlocks _ = toEnum 1

--- a/Raaz/Hash/Sha256/Internal.hs
+++ b/Raaz/Hash/Sha256/Internal.hs
@@ -49,4 +49,4 @@ instance Primitive SHA256 where
   type Implementation SHA256 = SomeHashI SHA256
 
 instance Hash SHA256 where
-  additionalPadBlocks _ = 1
+  additionalPadBlocks _ = toEnum 1

--- a/Raaz/Hash/Sha384/Implementation/CPortable.hs
+++ b/Raaz/Hash/Sha384/Implementation/CPortable.hs
@@ -44,4 +44,4 @@ implementation :: Implementation SHA384
 implementation =  SomeHashI cPortable
 
 cPortable :: HashI SHA384 SHA384Memory
-cPortable = truncatedI fromIntegral unSHA384Mem SHA512I.cPortable
+cPortable = truncatedI (toEnum . fromEnum) unSHA384Mem SHA512I.cPortable

--- a/Raaz/Hash/Sha384/Internal.hs
+++ b/Raaz/Hash/Sha384/Internal.hs
@@ -36,4 +36,4 @@ instance Primitive SHA384 where
   type Implementation SHA384 = SomeHashI SHA384
 
 instance Hash SHA384 where
-  additionalPadBlocks _ = 1
+  additionalPadBlocks _ = toEnum 1

--- a/Raaz/Hash/Sha512/Internal.hs
+++ b/Raaz/Hash/Sha512/Internal.hs
@@ -49,4 +49,4 @@ instance Initialisable (HashMemory SHA512) () where
                                   ]
 
 instance Hash SHA512 where
-  additionalPadBlocks _ = 1
+  additionalPadBlocks _ = toEnum 1


### PR DESCRIPTION
The num instance for block can lead to confusion with bytes. Remove it.