### PR TITLE
appveyor get cabal and ghc directly.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,11 +16,11 @@ before_test:
 - set GHCURL=https://downloads.haskell.org/~ghc/%GHCVER%/ghc-%GHCVER%-%ARCH%-unknown-mingw32.tar.xz
 - set CABALURL=https://www.haskell.org/cabal/release/cabal-install-%CABALVER%/cabal-install-%CABALVER%-%ARCH%-unknown-mingw32.zip
 - curl -S -ocabal.zip %CABALURL%
-- curl -S -oghc.zip  %GHCURL%
+- curl -S -oghc.txz  %GHCURL%
 - curl -S -ostack.zip -L --insecure http://www.stackage.org/stack/windows-%ARCH%
 - 7z x stack.zip stack.exe
 - 7z x cabal.zip
-- 7z x ghc.tar.xz
+- 7z x ghc.txz
 - set PATH=%APPVEYOR_BUILD_FOLDER%;%APPVERYOR_BUILD_FOLDER%/ghc-%GHCVER%/bin;%PATH%
 - ghc --version
 - cabal --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,6 @@ before_test:
 - 7z x ghc.txz
 - set PATH=%APPVEYOR_BUILD_FOLDER%;%APPVEYOR_BUILD_FOLDER%/ghc-%GHCVER%/bin;%PATH%
 - cabal --version
-- ghc --version
 - echo Some information of interest
 - echo %PATH%
 - pwd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,6 @@ before_test:
 - 7z x cabal.zip
 - 7z x ghc.txz
 - set PATH=%APPVEYOR_BUILD_FOLDER%;%APPVERYOR_BUILD_FOLDER%/ghc-%GHCVER%/bin;%PATH%
-- ghc --version
 - cabal --version
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,9 @@ before_test:
 - 7z x ghc.txz
 - set PATH=%APPVEYOR_BUILD_FOLDER%;%APPVERYOR_BUILD_FOLDER%/ghc-%GHCVER%/bin;%PATH%
 - cabal --version
+- echo Some information of interest
+- echo %PATH%
+- pwd
 
 test_script:
 - stack setup > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,18 +3,27 @@ build: off
 environment:
   global:
     STACK_ROOT: "c:\\sr"
+    CABALVER: "2.0.0.1"
+    GHCVER:   "8.2.2"
   matrix:
     - ARCH: x86_64
     - ARCH: i386
 
+clone_folder: "c:\\stack"
 before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
-
+- set GHCURL=https://downloads.haskell.org/~ghc/%GHCVER%/ghc-%GHCVER%-%ARCH%-unknown-mingw32.tar.xz
+- set CABALURL=https://www.haskell.org/cabal/release/cabal-install-%CABALVER%/cabal-install-%CABALVER%-%ARCH$-unknown-mingw32.zip
+- curl -sS -ocabal.zip %CABALURL%
+- curl -sS -oghc.zip  %GHCURL%
 - curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-%ARCH%
 - 7z x stack.zip stack.exe
-
-clone_folder: "c:\\stack"
+- 7z x cabal.zip cabal.exe
+- 7z x ghc.zip
+- set PATH=%APPVEYOR_BUILD_FOLDER%;%APPVERYOR_BUILD_FOLDER%/ghc-%GHCVER%/bin;%PATH%
+- ghc --version
+- cabal --version
 
 test_script:
 - stack setup > nul

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,12 +15,12 @@ before_test:
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 - set GHCURL=https://downloads.haskell.org/~ghc/%GHCVER%/ghc-%GHCVER%-%ARCH%-unknown-mingw32.tar.xz
 - set CABALURL=https://www.haskell.org/cabal/release/cabal-install-%CABALVER%/cabal-install-%CABALVER%-%ARCH$-unknown-mingw32.zip
-- curl -sS -ocabal.zip %CABALURL%
-- curl -sS -oghc.zip  %GHCURL%
-- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-%ARCH%
+- curl -S -ocabal.zip %CABALURL%
+- curl -S -oghc.zip  %GHCURL%
+- curl -S -ostack.zip -L --insecure http://www.stackage.org/stack/windows-%ARCH%
 - 7z x stack.zip stack.exe
-- 7z x cabal.zip cabal.exe
-- 7z x ghc.zip
+- 7z x cabal.zip
+- 7z x ghc.tar.xz
 - set PATH=%APPVEYOR_BUILD_FOLDER%;%APPVERYOR_BUILD_FOLDER%/ghc-%GHCVER%/bin;%PATH%
 - ghc --version
 - cabal --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 - set GHCURL=https://downloads.haskell.org/~ghc/%GHCVER%/ghc-%GHCVER%-%ARCH%-unknown-mingw32.tar.xz
-- set CABALURL=https://www.haskell.org/cabal/release/cabal-install-%CABALVER%/cabal-install-%CABALVER%-%ARCH$-unknown-mingw32.zip
+- set CABALURL=https://www.haskell.org/cabal/release/cabal-install-%CABALVER%/cabal-install-%CABALVER%-%ARCH%-unknown-mingw32.zip
 - curl -S -ocabal.zip %CABALURL%
 - curl -S -oghc.zip  %GHCURL%
 - curl -S -ostack.zip -L --insecure http://www.stackage.org/stack/windows-%ARCH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,9 @@ before_test:
 - 7z x stack.zip stack.exe
 - 7z x cabal.zip
 - 7z x ghc.txz
-- set PATH=%APPVEYOR_BUILD_FOLDER%;%APPVEYOR_BUILD_FOLDER%/ghc-%GHCVER%/bin;%PATH%
+- set PATH=%APPVEYOR_BUILD_FOLDER%;%APPVEYOR_BUILD_FOLDER%\ghc-%GHCVER%\bin;%PATH%
 - cabal --version
+- ghc   --version
 - echo Some information of interest
 - echo %PATH%
 - pwd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
     - ARCH: x86_64
     - ARCH: i386
 
-clone_folder: "c:\\stack"
+clone_folder: "c:\\raaz"
 before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
@@ -21,8 +21,9 @@ before_test:
 - 7z x stack.zip stack.exe
 - 7z x cabal.zip
 - 7z x ghc.txz
-- set PATH=%APPVEYOR_BUILD_FOLDER%;%APPVERYOR_BUILD_FOLDER%/ghc-%GHCVER%/bin;%PATH%
+- set PATH=%APPVEYOR_BUILD_FOLDER%;%APPVEYOR_BUILD_FOLDER%/ghc-%GHCVER%/bin;%PATH%
 - cabal --version
+- ghc --version
 - echo Some information of interest
 - echo %PATH%
 - pwd


### PR DESCRIPTION
Appveyor builds to use ghc and cabal directly. This is to support backpack.