### PR TITLE
appveyor: enable 32-bit and 64-bit builds.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 - choco install -y %ARCH_SEL_FLAG% ghc --version %GHCVER%
+- ghc --info | sls platform
 - refreshenv
 - cabal --version
 - ghc   --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,10 @@ before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
 - choco install -y %ARCH_SEL_FLAG% ghc --version %GHCVER%
-- ghc --info | sls platform
 - refreshenv
 - cabal --version
 - ghc   --version
+- ghc --info | Select-String -Pattern "platform"
 - cabal update
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,14 +5,14 @@ environment:
     GHCVER:   "8.2.2"
     STORE_DIR: "c:\\s"
   matrix:
-    - ARCH: x86_64
-    - ARCH: i386
+    - ARCH_SEL_FLAG: ""    # Default
+    - ARCH_SEL_FLAG: --x86 # Select 32-bit builds
 
 clone_folder: "c:\\raaz"
 before_test:
 # http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
 - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
-- choco install -y ghc --version %GHCVER%
+- choco install -y %ARCH_SEL_FLAG% ghc --version %GHCVER%
 - refreshenv
 - cabal --version
 - ghc   --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ before_test:
 - refreshenv
 - cabal --version
 - ghc   --version
-- ghc --info | Select-String -Pattern "platform"
+- ghc --info | grep "platform"
 - cabal update
 
 test_script:


### PR DESCRIPTION
This pull request tries to enable 32-bit ghc and tools on appveyor. It works towards #360.