### PR TITLE
chacha specialised for csprg

### DIFF
--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -25,6 +25,9 @@ import qualified Benchmark.Sha256.CHandWritten   as Sha256CHW
 import qualified Benchmark.Sha512.CPortable      as Sha512CP
 import qualified Benchmark.Sha512.CHandWritten   as Sha512CHW
 
+import qualified Benchmark.CSPRG.CPortable       as CSPRGCP
+import qualified Benchmark.CSPRG.CHandWritten    as CSPRGHW
+
 
 main :: IO ()
 main = do
@@ -37,6 +40,9 @@ main = do
 
                    , ChaCha20CP.bench
                    , ChaCha20CHW.bench
+
+                   , CSPRGCP.bench
+                   , CSPRGHW.bench
 
                    , Sha256CP.bench
                    , Sha256CHW.bench

--- a/benchmarks/internal/Benchmark/CSPRG.hs
+++ b/benchmarks/internal/Benchmark/CSPRG.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE FlexibleContexts #-}
+module Benchmark.CSPRG where
+
+import Control.Monad
+import GHC.TypeLits
+
+import Raaz.Core
+import ChaCha20.Utils
+import ChaCha20.Implementation
+import Benchmark.Types
+
+
+bench :: KnownNat BufferAlignment => RaazBench
+bench = (nm, toBenchmarkable $ action . fromIntegral)
+  where action count = allocBufferFor sz $ \ ptr -> insecurely $ replicateM_ count $ csprgBlocks ptr sz
+        nm = name ++ "-csprg"
+        sz = atLeast nBytes

--- a/implementation/ChaCha20/CHandWritten.hs
+++ b/implementation/ChaCha20/CHandWritten.hs
@@ -56,3 +56,9 @@ processLast :: AlignedPointer BufferAlignment
             -> BYTES Int
             -> MT Internals ()
 processLast buf = processBlocks buf . atLeast
+
+-- | Generate pseudo-random bytes using the chacha20 block function.
+csprgBlocks :: AlignedPointer BufferAlignment
+            -> BLOCKS Prim
+            -> MT Internals ()
+csprgBlocks = processBlocks

--- a/implementation/ChaCha20/CPortable.hs
+++ b/implementation/ChaCha20/CPortable.hs
@@ -44,3 +44,15 @@ processLast :: AlignedPointer BufferAlignment
             -> BYTES Int
             -> MT Internals ()
 processLast buf = processBlocks buf . atLeast
+
+csprgBlocks :: AlignedPointer BufferAlignment
+            -> BLOCKS Prim
+            -> MT Internals ()
+
+csprgBlocks buf blks =
+  do keyPtr     <- castPtr <$> keyCellPtr
+     ivPtr      <- castPtr <$> ivCellPtr
+     counterPtr <- castPtr <$> counterCellPtr
+     let blkPtr = castPtr $ forgetAlignment buf
+         wBlks  = toEnum $ fromEnum blks
+         in liftIO $ verse_chacha20_c_portable_keystream blkPtr wBlks keyPtr ivPtr counterPtr

--- a/indef/ChaCha20/Implementation.hsig
+++ b/indef/ChaCha20/Implementation.hsig
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds                   #-}
 -- | An implementation of a cryptographic primitive is a method to
 -- process data that is multiples of its block size. Fast
 -- implementations involve other details like the alignment
@@ -5,7 +6,10 @@
 -- in the following signature.
 signature ChaCha20.Implementation where
 
+import Raaz.Core
 import Raaz.Primitive.ChaCha20.Internal
+
+type BufferAlignment = 32
 
 -- | The primitive for which the implementation is given
 type Prim = ChaCha20
@@ -13,3 +17,8 @@ type Prim = ChaCha20
 -- | The type of the internals should be ChaCha20Mem, so that we can
 -- use it for our CSPRG.
 type Internals = ChaCha20Mem
+
+-- | Generate pseudo-random data in multiples of blocks.
+csprgBlocks :: AlignedPointer BufferAlignment
+            -> BLOCKS Prim
+            -> MT Internals ()

--- a/indef/ChaCha20/PRG.hs
+++ b/indef/ChaCha20/PRG.hs
@@ -15,6 +15,7 @@ import Prelude
 import Raaz.Core
 import Raaz.Primitive.ChaCha20.Internal
 import ChaCha20.Utils as U
+import ChaCha20.Implementation ( csprgBlocks )
 import Raaz.Entropy
 
 
@@ -52,8 +53,12 @@ data RandomState = RandomState { chacha20State  :: U.Internals
 
 -- | Apply chacha20 on the contents of the random buffer.
 chacha20Random :: MT RandomState ()
-chacha20Random = askBuffer >>= withReaderT chacha20State . U.processBuffer
+chacha20Random = askBuffer >>= withReaderT chacha20State . genCSPRG
   where askBuffer = auxBuffer <$> ask
+
+genCSPRG :: RandomBuffer -> MT Internals ()
+genCSPRG rbuf = csprgBlocks (getBufferPointer rbuf) $ bufferSize $ pure rbuf
+
 
 instance Memory RandomState where
   memoryAlloc     = RandomState <$> memoryAlloc <*> memoryAlloc <*> memoryAlloc

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -361,7 +361,7 @@ library bench-types
   import: bench-defaults
   exposed-modules: Benchmark.Types
 
-library bench-primitive-indef
+library bench-prim-indef
   import: bench-defaults
   build-depends: bench-types
                , indef
@@ -384,34 +384,34 @@ benchmark primitives
                , core
                , implementation
                , bench-types
-               , bench-primitive-indef
+               , bench-prim-indef
                , bench-csprg-indef
   other-modules: Benchmark.Types
-  mixins: bench-primitive-indef (Benchmark.Primitive as Benchmark.Blake2b.CPortable)
+  mixins: bench-prim-indef (Benchmark.Primitive as Benchmark.Blake2b.CPortable)
           requires   (Implementation as Blake2b.CPortable)
 
-        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Blake2b.CHandWritten)
+        , bench-prim-indef (Benchmark.Primitive as Benchmark.Blake2b.CHandWritten)
           requires   (Implementation as Blake2b.CHandWritten)
 
-        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Blake2s.CHandWritten)
+        , bench-prim-indef (Benchmark.Primitive as Benchmark.Blake2s.CHandWritten)
           requires   (Implementation as Blake2s.CHandWritten)
 
-        , bench-primitive-indef (Benchmark.Primitive as Benchmark.ChaCha20.CPortable)
+        , bench-prim-indef (Benchmark.Primitive as Benchmark.ChaCha20.CPortable)
           requires   (Implementation as ChaCha20.CPortable)
 
-        , bench-primitive-indef (Benchmark.Primitive as Benchmark.ChaCha20.CHandWritten)
+        , bench-prim-indef (Benchmark.Primitive as Benchmark.ChaCha20.CHandWritten)
           requires   (Implementation as ChaCha20.CHandWritten)
 
-        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Sha256.CPortable)
+        , bench-prim-indef (Benchmark.Primitive as Benchmark.Sha256.CPortable)
           requires   (Implementation as Sha256.CPortable)
 
-        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Sha256.CHandWritten)
+        , bench-prim-indef (Benchmark.Primitive as Benchmark.Sha256.CHandWritten)
           requires   (Implementation as Sha256.CHandWritten)
 
-        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Sha512.CPortable)
+        , bench-prim-indef (Benchmark.Primitive as Benchmark.Sha512.CPortable)
           requires (Implementation as Sha512.CPortable)
 
-        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Sha512.CHandWritten)
+        , bench-prim-indef (Benchmark.Primitive as Benchmark.Sha512.CHandWritten)
           requires (Implementation as Sha512.CHandWritten)
 
         , bench-csprg-indef (Benchmark.CSPRG as Benchmark.CSPRG.CPortable)

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -361,14 +361,14 @@ library bench-types
   import: bench-defaults
   exposed-modules: Benchmark.Types
 
-library bench-prim-indef
+library bench-prim
   import: bench-defaults
   build-depends: bench-types
                , indef
   other-modules: Benchmark.Types
   exposed-modules: Benchmark.Primitive
 
-library bench-csprg-indef
+library bench-csprg
   import: bench-defaults
   build-depends: bench-types
                , chacha20-indef
@@ -384,38 +384,38 @@ benchmark primitives
                , core
                , implementation
                , bench-types
-               , bench-prim-indef
-               , bench-csprg-indef
+               , bench-prim
+               , bench-csprg
   other-modules: Benchmark.Types
-  mixins: bench-prim-indef (Benchmark.Primitive as Benchmark.Blake2b.CPortable)
+  mixins: bench-prim (Benchmark.Primitive as Benchmark.Blake2b.CPortable)
           requires   (Implementation as Blake2b.CPortable)
 
-        , bench-prim-indef (Benchmark.Primitive as Benchmark.Blake2b.CHandWritten)
+        , bench-prim (Benchmark.Primitive as Benchmark.Blake2b.CHandWritten)
           requires   (Implementation as Blake2b.CHandWritten)
 
-        , bench-prim-indef (Benchmark.Primitive as Benchmark.Blake2s.CHandWritten)
+        , bench-prim (Benchmark.Primitive as Benchmark.Blake2s.CHandWritten)
           requires   (Implementation as Blake2s.CHandWritten)
 
-        , bench-prim-indef (Benchmark.Primitive as Benchmark.ChaCha20.CPortable)
+        , bench-prim (Benchmark.Primitive as Benchmark.ChaCha20.CPortable)
           requires   (Implementation as ChaCha20.CPortable)
 
-        , bench-prim-indef (Benchmark.Primitive as Benchmark.ChaCha20.CHandWritten)
+        , bench-prim (Benchmark.Primitive as Benchmark.ChaCha20.CHandWritten)
           requires   (Implementation as ChaCha20.CHandWritten)
 
-        , bench-prim-indef (Benchmark.Primitive as Benchmark.Sha256.CPortable)
+        , bench-prim (Benchmark.Primitive as Benchmark.Sha256.CPortable)
           requires   (Implementation as Sha256.CPortable)
 
-        , bench-prim-indef (Benchmark.Primitive as Benchmark.Sha256.CHandWritten)
+        , bench-prim (Benchmark.Primitive as Benchmark.Sha256.CHandWritten)
           requires   (Implementation as Sha256.CHandWritten)
 
-        , bench-prim-indef (Benchmark.Primitive as Benchmark.Sha512.CPortable)
+        , bench-prim (Benchmark.Primitive as Benchmark.Sha512.CPortable)
           requires (Implementation as Sha512.CPortable)
 
-        , bench-prim-indef (Benchmark.Primitive as Benchmark.Sha512.CHandWritten)
+        , bench-prim (Benchmark.Primitive as Benchmark.Sha512.CHandWritten)
           requires (Implementation as Sha512.CHandWritten)
 
-        , bench-csprg-indef (Benchmark.CSPRG as Benchmark.CSPRG.CPortable)
+        , bench-csprg (Benchmark.CSPRG as Benchmark.CSPRG.CPortable)
           requires (ChaCha20.Implementation as ChaCha20.CPortable)
 
-        , bench-csprg-indef (Benchmark.CSPRG as Benchmark.CSPRG.CHandWritten)
+        , bench-csprg (Benchmark.CSPRG as Benchmark.CSPRG.CHandWritten)
           requires (ChaCha20.Implementation as ChaCha20.CHandWritten)

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -347,49 +347,75 @@ test-suite tests
                , Raaz.Hash.Blake2Spec
 
 --------------------------- Benchmarkings ---------------------------------------------
-
-library bench-indef
-  import: defaults
-  hs-source-dirs: benchmarks/internal
-  exposed-modules: Benchmark.Primitive
-                 , Benchmark.Types
-  build-depends: criterion-measurement     >= 0.1
+common bench-defaults
+ import:defaults
+ hs-source-dirs: benchmarks/internal
+ build-depends:  criterion-measurement     >= 0.1
                , pretty
                , core
+
+
+
+
+library bench-types
+  import: bench-defaults
+  exposed-modules: Benchmark.Types
+
+library bench-primitive-indef
+  import: bench-defaults
+  build-depends: bench-types
                , indef
+  other-modules: Benchmark.Types
+  exposed-modules: Benchmark.Primitive
+
+library bench-csprg-indef
+  import: bench-defaults
+  build-depends: bench-types
+               , chacha20-indef
+  exposed-modules: Benchmark.CSPRG
+  other-modules: Benchmark.Types
 
 benchmark primitives
-  import: defaults
+  import: bench-defaults
   hs-source-dirs: benchmarks
   main-is: Main.hs
   type: exitcode-stdio-1.0
   build-depends: pretty
                , core
                , implementation
-               , bench-indef
-  mixins: bench-indef (Benchmark.Primitive as Benchmark.Blake2b.CPortable, Benchmark.Types)
+               , bench-types
+               , bench-primitive-indef
+               , bench-csprg-indef
+  other-modules: Benchmark.Types
+  mixins: bench-primitive-indef (Benchmark.Primitive as Benchmark.Blake2b.CPortable)
           requires   (Implementation as Blake2b.CPortable)
 
-        , bench-indef (Benchmark.Primitive as Benchmark.Blake2b.CHandWritten)
+        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Blake2b.CHandWritten)
           requires   (Implementation as Blake2b.CHandWritten)
 
-        , bench-indef (Benchmark.Primitive as Benchmark.Blake2s.CHandWritten)
+        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Blake2s.CHandWritten)
           requires   (Implementation as Blake2s.CHandWritten)
 
-        , bench-indef (Benchmark.Primitive as Benchmark.ChaCha20.CPortable)
+        , bench-primitive-indef (Benchmark.Primitive as Benchmark.ChaCha20.CPortable)
           requires   (Implementation as ChaCha20.CPortable)
 
-        , bench-indef (Benchmark.Primitive as Benchmark.ChaCha20.CHandWritten)
+        , bench-primitive-indef (Benchmark.Primitive as Benchmark.ChaCha20.CHandWritten)
           requires   (Implementation as ChaCha20.CHandWritten)
 
-        , bench-indef (Benchmark.Primitive as Benchmark.Sha256.CPortable)
+        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Sha256.CPortable)
           requires   (Implementation as Sha256.CPortable)
 
-        , bench-indef (Benchmark.Primitive as Benchmark.Sha256.CHandWritten)
+        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Sha256.CHandWritten)
           requires   (Implementation as Sha256.CHandWritten)
 
-        , bench-indef (Benchmark.Primitive as Benchmark.Sha512.CPortable)
+        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Sha512.CPortable)
           requires (Implementation as Sha512.CPortable)
 
-        , bench-indef (Benchmark.Primitive as Benchmark.Sha512.CHandWritten)
+        , bench-primitive-indef (Benchmark.Primitive as Benchmark.Sha512.CHandWritten)
           requires (Implementation as Sha512.CHandWritten)
+
+        , bench-csprg-indef (Benchmark.CSPRG as Benchmark.CSPRG.CPortable)
+          requires (ChaCha20.Implementation as ChaCha20.CPortable)
+
+        , bench-csprg-indef (Benchmark.CSPRG as Benchmark.CSPRG.CHandWritten)
+          requires (ChaCha20.Implementation as ChaCha20.CHandWritten)

--- a/tests/entropyquality.sh
+++ b/tests/entropyquality.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-stack exec raaz entropy | dieharder -a -g 200
+cabal new-exec raaz entropy | dieharder -a -g 200

--- a/tests/prgquality.sh
+++ b/tests/prgquality.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-stack exec raaz rand | dieharder -a -g 200
+cabal new-exec raaz rand | dieharder -a -g 200


### PR DESCRIPTION
Verse now exports a variant of chacha20 key stream generator that works with
host endian words. This is meant to be used as a csprg. We incorporate this
into raaz.