### PR TITLE
Make MAX_PATH errors more rare on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,9 @@ before_test:
 
 test_script:
 - chcp 65001
+- subst X: /D
+- subst X: .
+- pushd X:
 - cabal --store-dir=%STORE_DIR% new-configure --builddir=d
 - cabal --store-dir=%STORE_DIR% new-build --builddir=d
 - cabal --store-dir=%STORE_DIR% new-test  --builddir=d


### PR DESCRIPTION
this creates an alias to the `cwd` on the drive letter `X:` and makes everything relative to that. This means you gain `length(cwd)-2` of "free" space towards `MAX_PATH`..

Should make the error a bit rarer.