### PR TITLE
Buffer Alignment definition improved

### DIFF
--- a/indef/Implementation.hsig
+++ b/indef/Implementation.hsig
@@ -4,24 +4,23 @@
 {-# LANGUAGE MultiParamTypeClasses       #-}
 {-# LANGUAGE FlexibleInstances           #-}
 {-# LANGUAGE TypeFamilies                #-}
+{-# LANGUAGE CPP                         #-}
+
 
 -- | An implementation of a cryptographic primitive is a method to
 -- process data that is multiples of its block size. Fast
 -- implementations involve other details like the alignment
 -- restriction on the input buffer and all that. We package all this
 -- in the following signature.
-signature Implementation
-          ( Prim
-          , name
-          , description
-          , Internals
-          , BufferAlignment
-          , processBlocks
-          , processLast
-          , additionalBlocks
-          ) where
+signature Implementation where
 
 import Raaz.Core
+
+# if MIN_VERSION_base(4,13,0)
+
+import GHC.TypeLits
+
+# endif
 
 -- | The primitive for which the implementation is given
 data Prim
@@ -37,16 +36,17 @@ name :: String
 -- | Description of the implementation.
 description :: String
 
--- -- | The alignment requirements on the buffer.
--- data BufferAlignment :: Nat
--- instance KnownNat BufferAlignment
+# if MIN_VERSION_base(4,13,0)
 
--- | The buffer type for the primitve
+-- | The alignment requirements on the buffer.
+data BufferAlignment :: Nat
+instance KnownNat BufferAlignment
 
-
+# else
 -- | The alignment required for buffer (hack around bug
 -- https://ghc.haskell.org/trac/ghc/ticket/15138)
 type BufferAlignment = 32
+#endif
 
 -- | The additional space required in the buffer for processing the data.
 additionalBlocks :: BLOCKS Prim

--- a/indef/Utils.hs
+++ b/indef/Utils.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE MonoLocalBinds   #-}
+{-# LANGUAGE CPP              #-}
 module Utils
        ( processBuffer
        , processByteSource

--- a/indef/chacha20/Implementation.hsig
+++ b/indef/chacha20/Implementation.hsig
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses       #-}
 {-# LANGUAGE FlexibleInstances           #-}
 {-# LANGUAGE TypeFamilies                #-}
+{-# LANGUAGE CPP                         #-}
 
 -- | An implementation for chacha20 together with hchacha20 hash
 -- implementation.
@@ -12,6 +13,32 @@ signature Implementation where
 
 import Raaz.Core
 import Raaz.Primitive.ChaCha20.Internal
+
+-- NOTE:
+--
+-- With https://gitlab.haskell.org/ghc/ghc/issues/15138 and
+-- https://gitlab.haskell.org/ghc/ghc/issues/15379 fixed I (ppk) had
+-- expected that one can differ the assignment of Buffer
+-- alignment. While this is indeed the case for other implementations,
+-- for some reason it, does not seem to work for the Mac
+-- implementation, probably because of being an indirect constraint;
+-- Mac.Implementation -> Implementation but then is mixed as
+-- Implementation in the auth case. Therefore, I am setting an
+-- artificially large base number here.
+--
+# if MIN_VERSION_base(100,100,0)
+-- # if MIN_VERSION_base(4,13,0)
+import GHC.TypeLits
+
+-- | The alignment requirements on the buffer.
+data BufferAlignment :: Nat
+instance KnownNat BufferAlignment
+
+# else
+-- | The alignment required for buffer (hack around bug
+-- https://ghc.haskell.org/trac/ghc/ticket/15138)
+type BufferAlignment = 32
+#endif
 
 -- | The primitive for which the implementation is given
 

--- a/indef/keyed/hash/Implementation.hsig
+++ b/indef/keyed/hash/Implementation.hsig
@@ -1,8 +1,9 @@
+{-# LANGUAGE DataKinds                   #-}
 {-# LANGUAGE ConstraintKinds             #-}
 {-# LANGUAGE MultiParamTypeClasses       #-}
 {-# LANGUAGE FlexibleInstances           #-}
 {-# LANGUAGE TypeFamilies                #-}
-
+{-# LANGUAGE CPP                         #-}
 -- | A keyed primitive is something that expects a key for it to
 -- function. Examples include, encryption, encrypted-authentication
 -- etc. This signature add additional constraints to an implementation
@@ -10,17 +11,46 @@
 signature Implementation
           ( Prim
           , Internals
+          , BufferAlignment
           ) where
+
 
 import Foreign.Storable              (Storable)
 import Raaz.Core
 import Raaz.Primitive.Keyed.Internal (KeyedHash)
+
+-- NOTE:
+--
+-- With https://gitlab.haskell.org/ghc/ghc/issues/15138 and
+-- https://gitlab.haskell.org/ghc/ghc/issues/15379 fixed I (ppk) had
+-- expected that one can differ the assignment of Buffer
+-- alignment. While this is indeed the case for other implementations,
+-- for some reason it, does not seem to work for the Mac
+-- implementation, probably because of being an indirect constraint;
+-- Mac.Implementation -> Implementation but then is mixed as
+-- Implementation in the auth case. Therefore, I am setting an
+-- artificially large base number here.
+--
+# if MIN_VERSION_base(100,100,0)
+-- # if MIN_VERSION_base(4,13,0)
+import GHC.TypeLits
+
+-- | The alignment requirements on the buffer.
+data BufferAlignment :: Nat
+instance KnownNat BufferAlignment
+
+# else
+-- | The alignment required for buffer (hack around bug
+-- https://ghc.haskell.org/trac/ghc/ticket/15138)
+type BufferAlignment = 32
+#endif
 
 -- | The primitive for which the implementation is given
 data Prim
 instance Primitive Prim
 instance Storable  Prim
 instance KeyedHash Prim
+
 
 -- | The internal memory used by the implementation.
 data Internals

--- a/indef/keyed/hash/Mac/Implementation.hs
+++ b/indef/keyed/hash/Mac/Implementation.hs
@@ -42,8 +42,9 @@ name = Base.name ++ "-keyed-hash"
 
 -- | Description of the implementation.
 description :: String
-description = "Implementation of a MAC based on simple keyed hashing that makes use of " ++ Base.name
-              ++ "implementation."
+description = "Implementation of a MAC based on simple keyed hashing that makes use of "
+              ++ Base.name
+              ++ " implementation."
 
 type BufferAlignment = Base.BufferAlignment
 

--- a/raaz/bin/Command/Info.hs
+++ b/raaz/bin/Command/Info.hs
@@ -5,7 +5,6 @@ import           Options.Applicative
 import           Prelude
 import           Raaz
 import qualified Raaz.Core.CpuSupports as CpuSupports
-import           Raaz.Random          (entropySource, csprgName)
 import qualified Raaz.Auth.Blake2b
 import qualified Raaz.Auth.Blake2s
 import qualified Raaz.Digest.Blake2b


### PR DESCRIPTION
Now that backpack supports working with `KnownNat` constraints instead of explicit definitions, we do not have to fix the Buffer Alignment  through out.