### PR TITLE
Define word types for primitives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ matrix:
     - compiler: ghc-8.8.1
       addons: {apt: {packages: [cabal-install-3.0 ,ghc-8.8.1], sources: [hvr-ghc]}}
 
+    - compiler: ghc-8.10.1
+      addons: {apt: {packages: [cabal-install-3.0 ,ghc-8.10.1], sources: [hvr-ghc]}}
+
     - compiler: ghc-head
       addons: {apt: {packages: [cabal-install-head ,ghc-head], sources: [hvr-ghc]}}
 

--- a/api/aead/Cipher/Implementation.hsig
+++ b/api/aead/Cipher/Implementation.hsig
@@ -18,6 +18,6 @@ instance Memory Internals
 
 instance Initialisable Internals (Key Prim)
 instance Initialisable Internals (Nounce Prim)
-instance Initialisable Internals (BLOCKS Prim) -- To restore/advance
+instance Initialisable Internals (BlockCount Prim) -- To restore/advance
                                                -- to a particular
                                                -- block in the stream

--- a/api/encrypt/Implementation.hsig
+++ b/api/encrypt/Implementation.hsig
@@ -29,8 +29,8 @@ instance Memory Internals
 
 instance Initialisable Internals (Key Prim)
 instance Initialisable Internals (Nounce Prim)
-instance Initialisable Internals (BLOCKS Prim) -- To restore/advance
+instance Initialisable Internals (BlockCount Prim) -- To restore/advance
                                                -- to a particular
                                                -- block in the stream
 
-instance Extractable Internals (BLOCKS Prim)   -- To query the position
+instance Extractable Internals (BlockCount Prim)   -- To query the position

--- a/api/encrypt/Interface.hs
+++ b/api/encrypt/Interface.hs
@@ -29,7 +29,7 @@ encrypt key nounce = encryptAt key nounce mempty
 -- | Same as encrypt but first advances so many blocks.
 encryptAt :: Key Prim
           -> Nounce Prim
-          -> BLOCKS Prim
+          -> BlockCount Prim
           -> ByteString
           -> ByteString
 encryptAt key nounce blk bs = unsafePerformIO $ insecurely $ do
@@ -41,7 +41,7 @@ encryptAt key nounce blk bs = unsafePerformIO $ insecurely $ do
 -- | Same as decrypt but first advance so many blocks.
 decryptAt :: Key Prim
           -> Nounce Prim
-          -> BLOCKS Prim
+          -> BlockCount Prim
           -> ByteString
           -> ByteString
 decryptAt = encryptAt

--- a/api/random/Implementation.hsig
+++ b/api/random/Implementation.hsig
@@ -60,6 +60,6 @@ reseedAfter :: BlockCount Prim
 -- ignoring the endian considerations. In particular, if deterministic
 -- generation of random bytes across architectures are what is
 -- desired, this function is not suitable.
-randomBlocks :: AlignedPointer BufferAlignment
+randomBlocks :: AlignedBlockPtr BufferAlignment Prim
              -> BlockCount Prim
              -> MT Internals ()

--- a/api/random/Implementation.hsig
+++ b/api/random/Implementation.hsig
@@ -50,7 +50,7 @@ type RandomBufferSize = 16
 
 
 -- | How many blocks of the primitive to generated before re-seeding.
-reseedAfter :: BLOCKS Prim
+reseedAfter :: BlockCount Prim
 
 -- | Generate pseudo-random data in multiples of the blocks.  The sole
 -- purpose of this function is to stretch a fixed size seed (the key
@@ -61,5 +61,5 @@ reseedAfter :: BLOCKS Prim
 -- generation of random bytes across architectures are what is
 -- desired, this function is not suitable.
 randomBlocks :: AlignedPointer BufferAlignment
-             -> BLOCKS Prim
+             -> BlockCount Prim
              -> MT Internals ()

--- a/api/random/PRGenerator.hs
+++ b/api/random/PRGenerator.hs
@@ -101,7 +101,7 @@ type RandomBuffer = Buffer RandomBufferSize
 data RandomState = RandomState { internals       :: Internals
                                , auxBuffer       :: RandomBuffer
                                , remainingBytes  :: MemoryCell (BYTES Int)
-                               , blocksGenerated :: MemoryCell (BLOCKS Prim)
+                               , blocksGenerated :: MemoryCell (BlockCount Prim)
                                }
 
 

--- a/api/random/PRGenerator.hs
+++ b/api/random/PRGenerator.hs
@@ -205,7 +205,7 @@ fillExistingBytes req ptr = do
 -- | Transfer from existing bytes. This is unsafe because no checks is
 -- done to see if there are enough bytes to transfer.
 unsafeWithExisting :: BYTES Int
-                   -> (Pointer -> MT RandomState ())
+                   -> (BlockPtr Prim -> MT RandomState ())
                    -> MT RandomState ()
 unsafeWithExisting m action =  withAuxBuffer $ \ buf -> do
   r <- getRemainingBytes

--- a/benchmarks/internal/Benchmark/Primitive.hs
+++ b/benchmarks/internal/Benchmark/Primitive.hs
@@ -13,6 +13,9 @@ import Benchmark.Types
 
 bench :: KnownNat BufferAlignment => RaazBench
 bench = (nm, toBenchmarkable $ action . fromIntegral)
-  where action count = allocBufferFor sz $ \ ptr -> insecurely $ replicateM_ count $ processBlocks ptr sz
+  where action count = allocBufferFor sz
+                       $ \ ptr -> insecurely
+                                  $ replicateM_ count
+                                  $ processBlocks ptr sz
         nm = name
         sz = atLeast nBytes

--- a/core/Raaz/Core/MonoidalAction.hs
+++ b/core/Raaz/Core/MonoidalAction.hs
@@ -14,7 +14,7 @@ module Raaz.Core.MonoidalAction
 
 import Control.Arrow
 import Raaz.Core.Prelude
-
+import Raaz.Core.Types.Pointer
 
 ------------------ Actions and Monoidal actions -----------------------
 
@@ -230,3 +230,8 @@ instance (Arrow arrow, LAction m space) => LActionF m (WrappedArrow arrow space)
   {-# INLINE (<<.>>) #-}
 
 instance (Arrow arrow, LAction m space) => DistributiveF m (WrappedArrow arrow space)
+
+-- | The most interesting monoidal action for us.
+instance LengthUnit u => LAction u Pointer where
+  a <.> ptr  = movePtr ptr a
+  {-# INLINE (<.>) #-}

--- a/core/Raaz/Core/Primitive.hs
+++ b/core/Raaz/Core/Primitive.hs
@@ -18,8 +18,8 @@ module Raaz.Core.Primitive
        , BlockCount(..), blocksOf
        ) where
 
+import Data.Vector.Unboxed (Unbox)
 import GHC.TypeLits
-
 import Foreign.Ptr      ( Ptr      )
 import Foreign.Storable ( Storable )
 import Raaz.Core.Prelude
@@ -37,7 +37,10 @@ import Raaz.Core.Types.Tuple
 -- cryptographic primitive.
 --
 
-class (EndianStore (WordType p), KnownNat (WordsPerBlock p)) => Primitive p where
+class ( Unbox (WordType p)
+      , EndianStore (WordType p)
+      , KnownNat (WordsPerBlock p)
+      ) => Primitive p where
 
   -- | The block which is the smallest unit of data that the primitive
   -- processes, is typically considered as an array of a particular

--- a/core/Raaz/Core/Primitive.hs
+++ b/core/Raaz/Core/Primitive.hs
@@ -14,7 +14,7 @@ use a more high level interface.
 
 module Raaz.Core.Primitive
        ( -- * Cryptographic Primtives
-         Primitive(..), Key, Nounce, Block, BlockPtr
+         Primitive(..), Key, Nounce, Block, BlockPtr, AlignedBlockPtr
        , BlockCount(..), blocksOf
        ) where
 
@@ -64,9 +64,16 @@ data family Key p :: *
 -- primitive (if it requires one).
 data family Nounce p :: *
 
+-- | A block of the primitive.
 type Block p   = Tuple (WordsPerBlock p) (WordType p)
+
 -- | Pointer to a block of the primitive.
 type BlockPtr p = Ptr (Block p)
+
+-- | Aligned version of block pointers.
+
+type AlignedBlockPtr n p = AlignedPtr n (Block p)
+
 
 ------------------- Type safe lengths in units of block ----------------
 

--- a/core/Raaz/Core/Primitive.hs
+++ b/core/Raaz/Core/Primitive.hs
@@ -7,35 +7,50 @@ use a more high level interface.
 
 -}
 
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies                #-}
 {-# LANGUAGE FlexibleContexts            #-}
 {-# LANGUAGE DataKinds                   #-}
 
 module Raaz.Core.Primitive
        ( -- * Cryptographic Primtives
-         Primitive(..), Key, Nounce
+         Primitive(..), Key, Nounce, Block, BlockPtr
+       , BLOCKS(..), blocksOf
        ) where
 
 import GHC.TypeLits
 
+import Foreign.Ptr      ( Ptr      )
+import Foreign.Storable ( Storable )
+import Raaz.Core.Prelude
+import Raaz.Core.Types.Endian
+import Raaz.Core.Types.Pointer
+import Raaz.Core.Types.Tuple
+
 ----------------------- A primitive ------------------------------------
 
 
--- | The type class that captures an abstract block cryptographic
--- primitive.
-class KnownNat (BlockSize p) => Primitive p where
+-- | Cryptographic primitives that process bulk data (like ciphers,
+-- cryptographic hashes) process data in blocks. For data that is not
+-- a multiple of the block size they may have some padding
+-- strategy. The type class that captures an abstract block
+-- cryptographic primitive.
+--
 
-  -- | Bulk cryptographic primitives like hashes, ciphers etc often
-  -- acts on blocks of data. The size of the block is captured by the
-  -- associated type `BlockSize`.
-  type BlockSize p :: Nat
+class (EndianStore (WordType p), KnownNat (WordsPerBlock p)) => Primitive p where
 
-  -- | The key associated with primitive. In the setting of the raaz
-  -- library keys are "inputs" that are required to start processing.
-  -- Often primitives like ciphers have a /secret key/ together with
-  -- an additional nounce/IV. This type denotes not just the secret
-  -- key par but the nounce too.
-  --
+  -- | The block which is the smallest unit of data that the primitive
+  -- processes, is typically considered as an array of a particular
+  -- word which is captured by the following associated type.
+  type WordType p :: *
+
+  -- | The size of the array that forms the block. In particular, the
+  -- block can be seen as an array of size `BlockArraySize p` of type
+  -- `WORD p`.
+  type WordsPerBlock p :: Nat
+
+
+-- type BlockPtr p = Ptr (Tuple (BlockArraySize p) (WORD p)
 
 -- | The type family that captures the key of a keyed primitive.
 data family Key p :: *
@@ -45,3 +60,8 @@ data family Key p :: *
 -- sharing the key. The type family that captures the nounce for a
 -- primitive (if it requires one).
 data family Nounce p :: *
+
+type Block p   = Tuple (WordsPerBlock p) (WordType p)
+-- | Pointer to a block of the primitive.
+type BlockPtr p = Ptr (Block p)
+

--- a/core/Raaz/Core/Primitive.hs
+++ b/core/Raaz/Core/Primitive.hs
@@ -15,7 +15,7 @@ use a more high level interface.
 module Raaz.Core.Primitive
        ( -- * Cryptographic Primtives
          Primitive(..), Key, Nounce, Block, BlockPtr
-       , BLOCKS(..), blocksOf
+       , BlockCount(..), blocksOf
        ) where
 
 import GHC.TypeLits
@@ -69,27 +69,27 @@ type BlockPtr p = Ptr (Block p)
 
 -- | Type safe message length in units of blocks of the primitive.
 -- When dealing with buffer lengths for a primitive, it is often
--- better to use the type safe units `BLOCKS`. Functions in the raaz
+-- better to use the type safe units `BlockCount`. Functions in the raaz
 -- package that take lengths usually allow any type safe length as
 -- long as they can be converted to bytes. This can avoid a lot of
 -- tedious and error prone length calculations.
-newtype BLOCKS p = BLOCKS {unBLOCKS :: Int}
-                 deriving (Show, Eq, Ord, Enum, Storable)
+newtype BlockCount p = BlockCount {unBlockCount :: Int}
+                     deriving (Show, Eq, Ord, Enum, Storable)
 
-instance Semigroup (BLOCKS p) where
-  (<>) x y = BLOCKS $ unBLOCKS x + unBLOCKS y
-instance Monoid (BLOCKS p) where
-  mempty   = BLOCKS 0
+instance Semigroup (BlockCount p) where
+  (<>) x y = BlockCount $ unBlockCount x + unBlockCount y
+instance Monoid (BlockCount p) where
+  mempty   = BlockCount 0
   mappend  = (<>)
 
 
-instance Primitive p => LengthUnit (BLOCKS p) where
-  inBytes p@(BLOCKS x) = toEnum x * nWords p * wordSize p
+instance Primitive p => LengthUnit (BlockCount p) where
+  inBytes p@(BlockCount x) = toEnum x * nWords p * wordSize p
     where wordSize = sizeOf . proxyWT
           nWords   = toEnum . fromEnum . natVal . proxyWPB
-          proxyWT :: Primitive p => BLOCKS p -> Proxy (WordType p)
+          proxyWT :: Primitive p => BlockCount p -> Proxy (WordType p)
           proxyWT  = const Proxy
-          proxyWPB   :: Primitive p => BLOCKS p -> Proxy (WordsPerBlock p)
+          proxyWPB   :: Primitive p => BlockCount p -> Proxy (WordsPerBlock p)
           proxyWPB = const Proxy
 
 
@@ -97,5 +97,5 @@ instance Primitive p => LengthUnit (BLOCKS p) where
 -- lengths in units of the block length of the primitive whose proxy
 -- is @primProxy@. This expression is sometimes required to make the
 -- type checker happy.
-blocksOf :: Int -> Proxy p -> BLOCKS p
-blocksOf n _ = BLOCKS n
+blocksOf :: Int -> Proxy p -> BlockCount p
+blocksOf n _ = BlockCount n

--- a/core/Raaz/Core/Primitive.hs
+++ b/core/Raaz/Core/Primitive.hs
@@ -65,3 +65,37 @@ type Block p   = Tuple (WordsPerBlock p) (WordType p)
 -- | Pointer to a block of the primitive.
 type BlockPtr p = Ptr (Block p)
 
+------------------- Type safe lengths in units of block ----------------
+
+-- | Type safe message length in units of blocks of the primitive.
+-- When dealing with buffer lengths for a primitive, it is often
+-- better to use the type safe units `BLOCKS`. Functions in the raaz
+-- package that take lengths usually allow any type safe length as
+-- long as they can be converted to bytes. This can avoid a lot of
+-- tedious and error prone length calculations.
+newtype BLOCKS p = BLOCKS {unBLOCKS :: Int}
+                 deriving (Show, Eq, Ord, Enum, Storable)
+
+instance Semigroup (BLOCKS p) where
+  (<>) x y = BLOCKS $ unBLOCKS x + unBLOCKS y
+instance Monoid (BLOCKS p) where
+  mempty   = BLOCKS 0
+  mappend  = (<>)
+
+
+instance Primitive p => LengthUnit (BLOCKS p) where
+  inBytes p@(BLOCKS x) = toEnum x * nWords p * wordSize p
+    where wordSize = sizeOf . proxyWT
+          nWords   = toEnum . fromEnum . natVal . proxyWPB
+          proxyWT :: Primitive p => BLOCKS p -> Proxy (WordType p)
+          proxyWT  = const Proxy
+          proxyWPB   :: Primitive p => BLOCKS p -> Proxy (WordsPerBlock p)
+          proxyWPB = const Proxy
+
+
+-- | The expression @n `blocksOf` primProxy@ specifies the message
+-- lengths in units of the block length of the primitive whose proxy
+-- is @primProxy@. This expression is sometimes required to make the
+-- type checker happy.
+blocksOf :: Int -> Proxy p -> BLOCKS p
+blocksOf n _ = BLOCKS n

--- a/core/Raaz/Core/Transfer.hs
+++ b/core/Raaz/Core/Transfer.hs
@@ -156,9 +156,9 @@ transferSize = semiRMonoid
 
 -- | Perform the transfer without checking the bounds.
 unsafeTransfer :: Transfer t m
-               -> Pointer       -- ^ The pointer to the buffer to/from which transfer occurs.
+               -> Ptr a       -- ^ The pointer to the buffer to/from which transfer occurs.
                -> m ()
-unsafeTransfer tr = unTransferM . semiRSpace tr
+unsafeTransfer tr = unTransferM . semiRSpace tr . castPtr
 
 -- | The transfer @skip l@ skip ahead by an offset @l@. If it is a
 -- read, it does not read the next @l@ positions. If it is a write it
@@ -323,7 +323,7 @@ instance MonadIO m => IsString (WriteM m)  where
 
 instance Encodable WriteIO where
   {-# INLINE toByteString #-}
-  toByteString w  = unsafeCreate n $ unsafeTransfer w . castPtr
+  toByteString w  = unsafeCreate n $ unsafeTransfer w
     where BYTES n = transferSize w
 
   {-# INLINE unsafeFromByteString #-}

--- a/core/Raaz/Core/Types.hs
+++ b/core/Raaz/Core/Types.hs
@@ -11,7 +11,8 @@
 module Raaz.Core.Types
        ( -- * Overview.
          -- $overview$
-         module Raaz.Core.Types.Equality
+         module Raaz.Core.Primitive
+       , module Raaz.Core.Types.Equality
        , module Raaz.Core.Types.Endian
        , module Raaz.Core.Types.Pointer
        , module Raaz.Core.Types.Tuple
@@ -20,14 +21,16 @@ module Raaz.Core.Types
 
 import Raaz.Core.Types.Equality
 
+import Raaz.Core.Primitive            ( BLOCKS                  )
+
 -- Developer note: We want to expose LE and BE without its
 -- constructors. This is a ugly hack for it.
 import Raaz.Core.Types.Endian  hiding (LE, BE)
 import Raaz.Core.Types.Endian         (LE, BE)
 
-import Raaz.Core.Types.Pointer hiding ( AlignedPtr, BYTES, BITS, BLOCKS)
-import Raaz.Core.Types.Pointer        ( AlignedPtr, BYTES, BITS, BLOCKS)
-import Raaz.Core.Types.Tuple   hiding ( map                            )
+import Raaz.Core.Types.Pointer hiding ( AlignedPtr, BYTES, BITS )
+import Raaz.Core.Types.Pointer        ( AlignedPtr, BYTES, BITS )
+import Raaz.Core.Types.Tuple   hiding ( map                     )
 import Raaz.Core.Types.Copying( Src, Dest, source, destination)
 
 

--- a/core/Raaz/Core/Types.hs
+++ b/core/Raaz/Core/Types.hs
@@ -21,7 +21,7 @@ module Raaz.Core.Types
 
 import Raaz.Core.Types.Equality
 
-import Raaz.Core.Primitive            ( BLOCKS                  )
+import Raaz.Core.Primitive            ( BlockCount                  )
 
 -- Developer note: We want to expose LE and BE without its
 -- constructors. This is a ugly hack for it.

--- a/core/Raaz/Core/Types/Internal.hs
+++ b/core/Raaz/Core/Types/Internal.hs
@@ -17,15 +17,17 @@
 -- >    :: Pointer -> Pointer -> Int -> IO Pointer
 
 module Raaz.Core.Types.Internal
-       ( module Raaz.Core.Types.Endian
+       ( module Raaz.Core.Primitive
+       , module Raaz.Core.Types.Endian
        , module Raaz.Core.Types.Pointer
        , module Raaz.Core.Types.Copying
        , module Raaz.Core.Types.Tuple
        ) where
 
+import Raaz.Core.Primitive     ( BLOCKS (..) )
 import Raaz.Core.Types.Endian  ( LE(..), BE(..)          )
 import Raaz.Core.Types.Pointer ( Pointer, AlignedPtr(..)
-                               , BITS(..), BYTES(..), BLOCKS(..)
+                               , BITS(..), BYTES(..)
                                )
 import Raaz.Core.Types.Copying ( Src(..), Dest(..)       )
 import Raaz.Core.Types.Tuple

--- a/core/Raaz/Core/Types/Internal.hs
+++ b/core/Raaz/Core/Types/Internal.hs
@@ -24,7 +24,7 @@ module Raaz.Core.Types.Internal
        , module Raaz.Core.Types.Tuple
        ) where
 
-import Raaz.Core.Primitive     ( BLOCKS (..) )
+import Raaz.Core.Primitive     ( BlockCount (..) )
 import Raaz.Core.Types.Endian  ( LE(..), BE(..)          )
 import Raaz.Core.Types.Pointer ( Pointer, AlignedPtr(..)
                                , BITS(..), BYTES(..)

--- a/core/Raaz/Core/Types/Pointer.hs
+++ b/core/Raaz/Core/Types/Pointer.hs
@@ -13,6 +13,7 @@
 module Raaz.Core.Types.Pointer
        ( -- * Pointers, offsets, and alignment
          Pointer, AlignedPointer, AlignedPtr(..), onPtr, ptrAlignment, nextAlignedPtr
+       , castAlignedPtr
          -- ** Type safe length units.
        , LengthUnit(..)
        , BYTES(..), BITS(..), inBits
@@ -41,7 +42,7 @@ import           Control.Monad.IO.Class
 
 import           Data.Vector.Unboxed         ( MVector(..), Vector, Unbox )
 import           Foreign.Marshal.Alloc
-import           Foreign.Ptr           ( Ptr                  )
+import           Foreign.Ptr           ( Ptr, castPtr         )
 import qualified Foreign.Ptr           as FP
 import           Foreign.Storable      ( Storable, peek, poke )
 import qualified Foreign.Storable      as FS
@@ -81,6 +82,10 @@ type Pointer = Ptr Byte
 -- | The type @AlignedPtr n@ that captures pointers that are aligned
 -- to @n@ byte boundary.
 newtype AlignedPtr (n :: Nat) a = AlignedPtr { forgetAlignment :: Ptr a}
+
+-- | Change the type of the aligned pointer not its alignment.
+castAlignedPtr :: AlignedPtr n a -> AlignedPtr n b
+castAlignedPtr = AlignedPtr . castPtr . forgetAlignment
 
 type AlignedPointer n = AlignedPtr n Byte
 

--- a/core/Raaz/Core/Types/Pointer.hs
+++ b/core/Raaz/Core/Types/Pointer.hs
@@ -243,11 +243,6 @@ bitsQuot bits = u
         q       = bits `quot` divisor
         u       = toEnum $ fromEnum q
 
--- | The most interesting monoidal action for us.
-instance LengthUnit u => LAction u Pointer where
-  a <.> ptr  = movePtr ptr a
-  {-# INLINE (<.>) #-}
-
 --------------------------
 
 instance Unbox w => Unbox (BYTES w)

--- a/core/Raaz/Core/Types/Pointer.hs
+++ b/core/Raaz/Core/Types/Pointer.hs
@@ -27,7 +27,6 @@ module Raaz.Core.Types.Pointer
        , alignment, alignPtr, movePtr, alignedSizeOf, nextLocation, peekAligned, pokeAligned
          -- ** Allocation functions.
        , allocaBuffer, allocaAligned, allocaSecure
-       , mallocBuffer
          -- ** Some buffer operations
        , memset
        , wipeMemory
@@ -427,18 +426,6 @@ foreign import ccall unsafe "raaz/core/memory.h raazMemorylock"
 
 foreign import ccall unsafe "raaz/core/memory.h raazMemoryunlock"
   c_munlock :: Pointer -> BYTES Int -> IO ()
-
-
-
--- | Creates a memory of given size. It is better to use over
--- @`mallocBytes`@ as it uses typesafe length.
-mallocBuffer :: LengthUnit l
-             => l                    -- ^ buffer length
-             -> IO Pointer
-{-# INLINE mallocBuffer #-}
-mallocBuffer l = mallocBytes bytes
-  where BYTES bytes = inBytes l
-
 
 -------------------- Low level pointer operations ------------------
 

--- a/core/Raaz/Core/Types/Tuple.hs
+++ b/core/Raaz/Core/Types/Tuple.hs
@@ -161,7 +161,10 @@ initial ::  (V.Unbox a, Dimension dim0)
          => Tuple dim1 a
          -> Tuple dim0 a
 initial = mkTuple Proxy
-  where mkTuple :: (V.Unbox a, Dimension dim0) => Proxy (Tuple dim0 a) -> Tuple dim1 a  -> Tuple dim0 a
+  where mkTuple :: (V.Unbox a, Dimension dim0)
+                => Proxy (Tuple dim0 a)
+                -> Tuple dim1 a
+                -> Tuple dim0 a
         mkTuple uTupProxy tup = Tuple $ V.take (dimension' uTupProxy) $ unTuple tup
 
 -- TODO: Put a constraint that dim0 <= dim1

--- a/core/Raaz/Core/Types/Tuple.hs
+++ b/core/Raaz/Core/Types/Tuple.hs
@@ -90,8 +90,7 @@ dimension' :: Dimension dim => Proxy (Tuple dim a) -> Int
 dimension' = dimensionP Proxy
 
 -- | Get the dimension to parser
-getParseDimension :: (V.Unbox a, Dimension dim)
-                  => Parser (Tuple dim a) -> Int
+getParseDimension :: Dimension dim => Parser (Tuple dim a) -> Int
 getParseDimension = dimension' . getProxy
   where getProxy :: Parser (Tuple dim a) -> Proxy (Tuple dim a)
         getProxy = const Proxy
@@ -131,9 +130,12 @@ instance (V.Unbox a, EndianStore a, Dimension dim)
 
 
 -- | Construct a tuple by repeating a monadic action.
-repeatM :: (Functor m, Monad m, V.Unbox a, Dimension dim) => m a -> m (Tuple dim a)
+repeatM :: ( Monad m, V.Unbox a, Dimension dim) => m a -> m (Tuple dim a)
 repeatM = mkTupM Proxy
-  where mkTupM :: (Functor m, V.Unbox a, Monad m, Dimension dim) => Proxy (Tuple dim a) -> m a -> m (Tuple dim a)
+  where mkTupM :: (Monad m, V.Unbox a, Dimension dim)
+               => Proxy (Tuple dim a)
+               -> m a
+               -> m (Tuple dim a)
         mkTupM uTupProxy action = Tuple <$> V.replicateM (dimension' uTupProxy) action
 
 

--- a/core/Raaz/Core/Util/ByteString.hs
+++ b/core/Raaz/Core/Util/ByteString.hs
@@ -7,7 +7,6 @@ Some utility function for byte strings.
 {-# LANGUAGE FlexibleContexts #-}
 module Raaz.Core.Util.ByteString
        ( length, replicate
-       , fromByteStringStorable
        , create, createFrom
        , withByteString
        , unsafeCopyToPointer
@@ -70,11 +69,6 @@ unsafeNCopyToPointer n bs cptr = withForeignPtr fptr $
 withByteString :: ByteString -> (Pointer -> IO a) -> IO a
 withByteString bs f = withForeignPtr fptr (f . flip plusPtr off . castPtr)
   where (fptr, off, _) = BI.toForeignPtr bs
-
--- | Get the value from the bytestring using `peek`.
-fromByteStringStorable :: Storable k => ByteString -> k
-fromByteStringStorable str = unsafePerformIO $ withByteString str (peek . castPtr)
-
 
 -- | The action @create l act@ creates a length @l@ bytestring where
 -- the contents are filled using the the @act@ to fill the buffer.

--- a/core/Raaz/Core/Util/ByteString.hs
+++ b/core/Raaz/Core/Util/ByteString.hs
@@ -40,12 +40,11 @@ replicate l = B.replicate sz
 -- undefined behaviour if the crypto pointer points to an area smaller
 -- than the size of the byte string.
 unsafeCopyToPointer :: ByteString   -- ^ The source.
-                    -> Pointer      -- ^ The destination.
+                    -> Ptr a        -- ^ The destination.
                     -> IO ()
 unsafeCopyToPointer bs cptr =  withForeignPtr fptr $
-           \ p -> memcpy dptr (source $ p `plusPtr` offset) (BYTES n)
+           \ p -> memcpy (destination cptr) (source $ p `plusPtr` offset) (BYTES n)
     where (fptr, offset,n) = BI.toForeignPtr bs
-          dptr = destination $ castPtr cptr
 
 
 -- | Similar to `unsafeCopyToPointer` but takes an additional input
@@ -54,32 +53,31 @@ unsafeCopyToPointer bs cptr =  withForeignPtr fptr $
 -- either the bytestring is shorter than @n@ or the crypto pointer
 -- points to an area smaller than @n@.
 unsafeNCopyToPointer :: LengthUnit n
-                       => n              -- ^ length of data to be copied
-                       -> ByteString     -- ^ The source byte string
-                       -> Pointer        -- ^ The buffer
-                       -> IO ()
+                     => n              -- ^ length of data to be copied
+                     -> ByteString     -- ^ The source byte string
+                     -> Ptr a         -- ^ The buffer
+                     -> IO ()
 unsafeNCopyToPointer n bs cptr = withForeignPtr fptr $
-           \ p -> memcpy dptr (source $ p `plusPtr` offset) n
+           \ p -> memcpy (destination cptr) (source $ p `plusPtr` offset) n
     where (fptr, offset,_) = BI.toForeignPtr bs
-          dptr             = destination $ castPtr cptr
 
 -- | Works directly on the pointer associated with the
 -- `ByteString`. This function should only read and not modify the
 -- contents of the pointer.
-withByteString :: ByteString -> (Pointer -> IO a) -> IO a
-withByteString bs f = withForeignPtr fptr (f . flip plusPtr off . castPtr)
+withByteString :: ByteString -> (Ptr something -> IO a) -> IO a
+withByteString bs f = withForeignPtr fptr (f . flip plusPtr off)
   where (fptr, off, _) = BI.toForeignPtr bs
 
 -- | The action @create l act@ creates a length @l@ bytestring where
 -- the contents are filled using the the @act@ to fill the buffer.
-create :: LengthUnit l => l -> (Pointer -> IO ()) -> IO ByteString
+create :: LengthUnit l => l -> (Ptr a -> IO ()) -> IO ByteString
 create l act = myCreate (act . castPtr)
   where myCreate =  BI.create $ fromIntegral $ inBytes l
 
 -- | The IO action @createFrom n cptr@ creates a bytestring by copying
 -- @n@ bytes from the pointer @cptr@.
-createFrom :: LengthUnit l => l -> Pointer -> IO ByteString
+createFrom :: LengthUnit l => l -> Ptr a -> IO ByteString
 createFrom l cptr = create l filler
-  where filler dptr = memcpy (destination $ castPtr dptr) (source cptr) l
+  where filler dptr = memcpy (destination dptr) (source cptr) l
 
 ----------------------  Hexadecimal encoding. -----------------------------------

--- a/core/Raaz/Primitive/Blake2/Internal.hs
+++ b/core/Raaz/Primitive/Blake2/Internal.hs
@@ -28,7 +28,9 @@ import           Raaz.Primitive.Keyed.Internal
 newtype Blake2 w = Blake2 (Tuple 8 w)
                deriving (Eq, Equality, Storable, EndianStore)
 
-instance EndianStore w => Primitive (Blake2 w) where
+instance ( Unbox w
+         , EndianStore w
+         ) => Primitive (Blake2 w) where
   type WordType      (Blake2 w) = w
   type WordsPerBlock (Blake2 w) = 16 
 

--- a/core/Raaz/Primitive/Blake2/Internal.hs
+++ b/core/Raaz/Primitive/Blake2/Internal.hs
@@ -15,6 +15,7 @@ module Raaz.Primitive.Blake2.Internal
        ) where
 
 import           Control.Monad.IO.Class
+import           Data.Vector.Unboxed        ( Unbox )
 import           Foreign.Storable           ( Storable       )
 
 import           Raaz.Core
@@ -27,40 +28,23 @@ import           Raaz.Primitive.Keyed.Internal
 newtype Blake2 w = Blake2 (Tuple 8 w)
                deriving (Eq, Equality, Storable, EndianStore)
 
--- | Word type for Blake2b
-type Word2b = LE Word64
+instance EndianStore w => Primitive (Blake2 w) where
+  type WordType      (Blake2 w) = w
+  type WordsPerBlock (Blake2 w) = 16 
 
--- | Word type for Blake2s
-type Word2s = LE Word32
+instance (Unbox w, EndianStore w) => Encodable (Blake2 w)
+
+instance (EndianStore w, Unbox w) => IsString (Blake2 w) where
+  fromString = fromBase16
+
+instance (EndianStore w, Unbox w) => Show (Blake2 w) where
+  show =  showBase16
 
 -- | The Blake2b hash type.
-type Blake2b = Blake2 Word2b
+type Blake2b = Blake2 (LE Word64)
 
 -- | The Blake2s hash type.
-type Blake2s = Blake2 Word2s
-
-instance Encodable Blake2b
-instance Encodable Blake2s
-
-
-instance IsString Blake2b where
-  fromString = fromBase16
-
-instance IsString Blake2s where
-  fromString = fromBase16
-
-instance Show Blake2b where
-  show =  showBase16
-
-instance Show Blake2s where
-  show =  showBase16
-
-instance Primitive Blake2b where
-  type BlockSize Blake2b      = 128
-
-instance Primitive Blake2s where
-  type BlockSize Blake2s      = 64
-
+type Blake2s = Blake2 (LE Word32)
 
 keyLength :: (Storable prim, Num b) => Proxy prim -> BYTES Int -> b
 keyLength proxy len

--- a/core/Raaz/Primitive/ChaCha20/Internal.hs
+++ b/core/Raaz/Primitive/ChaCha20/Internal.hs
@@ -115,14 +115,14 @@ instance Initialisable ChaCha20Mem (Key ChaCha20) where
 instance Initialisable ChaCha20Mem (Nounce ChaCha20)  where
   initialise  = withReaderT ivCell . initialise
 
-instance Initialisable ChaCha20Mem (BLOCKS ChaCha20) where
+instance Initialisable ChaCha20Mem (BlockCount ChaCha20) where
   initialise = withReaderT counterCell . initialise . conv
-    where conv :: BLOCKS ChaCha20 -> WORD
+    where conv :: BlockCount ChaCha20 -> WORD
           conv = toEnum . fromEnum
 
-instance Extractable ChaCha20Mem (BLOCKS ChaCha20) where
+instance Extractable ChaCha20Mem (BlockCount ChaCha20) where
   extract = conv <$> withReaderT counterCell extract
-    where conv :: WORD -> BLOCKS ChaCha20
+    where conv :: WORD -> BlockCount ChaCha20
           conv = toEnum . fromEnum
 
 -- | Initialises key from a buffer. Use this instance if you want to

--- a/core/Raaz/Primitive/ChaCha20/Internal.hs
+++ b/core/Raaz/Primitive/ChaCha20/Internal.hs
@@ -9,7 +9,6 @@
 -- (4-byte) counter and 96-bit (12-byte) IV.
 module Raaz.Primitive.ChaCha20.Internal
        ( ChaCha20(..), XChaCha20(..)
-       , WORD
        , Key(..), Nounce(..)
        , ChaCha20Mem(..)
        , keyCellPtr, ivCellPtr, counterCellPtr
@@ -28,19 +27,21 @@ data ChaCha20 = ChaCha20
 -- | The type associated with the XChaCha20 variant.
 data XChaCha20 = XChaCha20
 
-
-instance Primitive ChaCha20 where
-  type BlockSize ChaCha20      = 64
-
-instance Primitive XChaCha20 where
-  type BlockSize XChaCha20     = 64
-
--- | The word type
 type WORD     = LE Word32
 type KEY      = Tuple 8 WORD
 
-newtype instance Key     ChaCha20 = Key     KEY
+instance Primitive ChaCha20 where
+  type WordType      ChaCha20 = WORD
+  type WordsPerBlock ChaCha20 = 16
+
+instance Primitive XChaCha20 where
+  type WordType      XChaCha20  = WORD
+  type WordsPerBlock XChaCha20  = 16
+
+
+newtype instance Key     ChaCha20 = Key KEY
   deriving (Storable, EndianStore, Equality, Eq)
+
 newtype instance Nounce  ChaCha20 = Nounce  (Tuple 3 WORD)
   deriving (Storable, EndianStore, Equality, Eq)
 
@@ -62,7 +63,7 @@ instance IsString (Nounce ChaCha20) where
   fromString = fromBase16
 
 
-newtype instance Key     XChaCha20 = XKey     KEY
+newtype instance Key     XChaCha20 = XKey KEY
   deriving (Storable, EndianStore)
 newtype instance Nounce  XChaCha20 = XNounce  (Tuple 6 WORD)
   deriving (Storable, EndianStore)

--- a/core/Raaz/Primitive/Keyed/Internal.hs
+++ b/core/Raaz/Primitive/Keyed/Internal.hs
@@ -37,7 +37,8 @@ instance Show prim => Show (Keyed prim) where
   show = show . unsafeToPrim
 
 instance Primitive prim => Primitive (Keyed prim) where
-  type BlockSize (Keyed prim) = BlockSize prim
+  type WordType      (Keyed prim)  = WordType prim
+  type WordsPerBlock (Keyed prim)  = WordsPerBlock prim 
 
 --------------- Key used by the keyed prim -----------------------------
 

--- a/core/Raaz/Primitive/Poly1305/Internal.hs
+++ b/core/Raaz/Primitive/Poly1305/Internal.hs
@@ -66,6 +66,7 @@ instance Show S where
   show = showBase16
 
 instance Primitive Poly1305 where
-  type BlockSize Poly1305      = 16
+  type WordType      Poly1305  = Word8
+  type WordsPerBlock Poly1305  = 16
 
 data instance Key Poly1305  = Key R S deriving Show

--- a/core/Raaz/Primitive/Sha2/Internal.hs
+++ b/core/Raaz/Primitive/Sha2/Internal.hs
@@ -89,11 +89,11 @@ instance Initialisable Sha512Mem () where
 
 -- | The block compressor for sha256.
 type Compressor256 n =  AlignedPointer n
-                     -> BLOCKS Sha256
+                     -> BlockCount Sha256
                      -> MT Sha256Mem ()
 -- | The block compressor for sha512
 type Compressor512 n =  AlignedPointer n
-                     -> BLOCKS Sha512
+                     -> BlockCount Sha512
                      -> MT Sha512Mem ()
 
 -- | Takes a block processing function for sha256 and gives a last

--- a/core/Raaz/Primitive/Sha2/Internal.hs
+++ b/core/Raaz/Primitive/Sha2/Internal.hs
@@ -29,7 +29,9 @@ import           Raaz.Primitive.HashMemory
 newtype Sha2 w = Sha2 (Tuple 8 w)
                deriving (Eq, Equality, Storable, EndianStore)
 
-instance EndianStore w => Primitive (Sha2 w) where
+instance ( Unbox w
+         , EndianStore w
+         ) => Primitive (Sha2 w) where
   type WordType      (Sha2 w) = w
   type WordsPerBlock (Sha2 w) = 16 
 

--- a/core/Raaz/Primitive/Sha2/Internal.hs
+++ b/core/Raaz/Primitive/Sha2/Internal.hs
@@ -16,6 +16,7 @@ module Raaz.Primitive.Sha2.Internal
        ) where
 
 import           Control.Monad.IO.Class     ( MonadIO      )
+import           Data.Vector.Unboxed        ( Unbox )
 import           Foreign.Storable           ( Storable(..) )
 
 import           Raaz.Core
@@ -28,33 +29,25 @@ import           Raaz.Primitive.HashMemory
 newtype Sha2 w = Sha2 (Tuple 8 w)
                deriving (Eq, Equality, Storable, EndianStore)
 
+instance EndianStore w => Primitive (Sha2 w) where
+  type WordType      (Sha2 w) = w
+  type WordsPerBlock (Sha2 w) = 16 
+
+
+instance (Unbox w, EndianStore w) => Encodable (Sha2 w)
+
+instance (EndianStore w, Unbox w) => IsString (Sha2 w) where
+  fromString = fromBase16
+
+instance (EndianStore w, Unbox w) => Show (Sha2 w) where
+  show =  showBase16
+
+
 -- | The Sha512 cryptographic hash.
 type Sha512 = Sha2 (BE Word64)
 
 -- | The Sha256 cryptographic hash.
 type Sha256 = Sha2 (BE Word32)
-
-instance Encodable Sha512
-instance Encodable Sha256
-
-
-instance IsString Sha512 where
-  fromString = fromBase16
-
-instance IsString Sha256 where
-  fromString = fromBase16
-
-instance Show Sha512 where
-  show =  showBase16
-
-instance Show Sha256 where
-  show =  showBase16
-
-instance Primitive Sha512 where
-  type BlockSize Sha512      = 128
-
-instance Primitive Sha256 where
-  type BlockSize Sha256      = 64
 
 -- | The initial value to start the blake2b hashing. This is equal to
 -- the iv `xor` the parameter block.

--- a/core/Raaz/Primitive/Sha2/Internal.hs
+++ b/core/Raaz/Primitive/Sha2/Internal.hs
@@ -90,18 +90,18 @@ instance Initialisable Sha512Mem () where
 
 
 -- | The block compressor for sha256.
-type Compressor256 n =  AlignedPointer n
+type Compressor256 n =  AlignedBlockPtr n Sha256
                      -> BlockCount Sha256
                      -> MT Sha256Mem ()
 -- | The block compressor for sha512
-type Compressor512 n =  AlignedPointer n
+type Compressor512 n =  AlignedBlockPtr n Sha512
                      -> BlockCount Sha512
                      -> MT Sha512Mem ()
 
 -- | Takes a block processing function for sha256 and gives a last
 -- bytes processor.
 process256Last :: Compressor256 n    -- ^ block compressor
-               -> AlignedPointer n
+               -> AlignedBlockPtr n Sha256
                -> BYTES Int
                -> MT Sha256Mem ()
 process256Last comp buf nbytes  = do
@@ -114,7 +114,7 @@ process256Last comp buf nbytes  = do
 -- | Takes a block processing function for sha512 and gives a last
 -- bytes processor.
 process512Last :: Compressor512 n
-               -> AlignedPointer n
+               -> AlignedBlockPtr n Sha512
                -> BYTES Int
                -> MT Sha512Mem ()
 process512Last comp buf nbytes  = do

--- a/implementation/Blake2b/CHandWritten.hs
+++ b/implementation/Blake2b/CHandWritten.hs
@@ -23,7 +23,7 @@ description = "Hand written Blake2b Implementation in portable C and Haskell FFI
 type Prim                    = Blake2b
 type Internals               = Blake2bMem
 type BufferAlignment         = 32
-
+type BufferPtr               = AlignedBlockPtr BufferAlignment Prim
 
 additionalBlocks :: BlockCount Blake2b
 additionalBlocks = blocksOf 1 Proxy
@@ -33,7 +33,7 @@ additionalBlocks = blocksOf 1 Proxy
 
 foreign import ccall unsafe
   "raaz/hash/blake2/common.h raazHashBlake2bPortableBlockCompress"
-  c_blake2b_compress  :: AlignedPointer BufferAlignment
+  c_blake2b_compress  :: BufferPtr
                       -> BlockCount Prim
                       -> Ptr (BYTES Word64)
                       -> Ptr (BYTES Word64)
@@ -42,7 +42,7 @@ foreign import ccall unsafe
 
 foreign import ccall unsafe
   "raaz/hash/blake2/common.h raazHashBlake2bPortableLastBlock"
-  c_blake2b_last   :: Pointer
+  c_blake2b_last   :: BlockPtr Prim
                    -> BYTES Int
                    -> BYTES Word64
                    -> BYTES Word64
@@ -52,7 +52,7 @@ foreign import ccall unsafe
                    -> IO ()
 
 --
-processBlocks :: AlignedPointer BufferAlignment
+processBlocks :: BufferPtr
               -> BlockCount Blake2b
               -> MT Blake2bMem ()
 
@@ -62,7 +62,7 @@ processBlocks buf blks = do uPtr   <- uLengthCellPointer
                             liftIO $ c_blake2b_compress buf blks uPtr lPtr hshPtr
 
 -- | Process the last bytes.
-processLast :: AlignedPointer BufferAlignment
+processLast :: BufferPtr
             -> BYTES Int
             -> MT Blake2bMem ()
 processLast buf nbytes  = do

--- a/implementation/Blake2b/CHandWritten.hs
+++ b/implementation/Blake2b/CHandWritten.hs
@@ -25,7 +25,7 @@ type Internals               = Blake2bMem
 type BufferAlignment         = 32
 
 
-additionalBlocks :: BLOCKS Blake2b
+additionalBlocks :: BlockCount Blake2b
 additionalBlocks = blocksOf 1 Proxy
 
 
@@ -34,7 +34,7 @@ additionalBlocks = blocksOf 1 Proxy
 foreign import ccall unsafe
   "raaz/hash/blake2/common.h raazHashBlake2bPortableBlockCompress"
   c_blake2b_compress  :: AlignedPointer BufferAlignment
-                      -> BLOCKS Prim
+                      -> BlockCount Prim
                       -> Ptr (BYTES Word64)
                       -> Ptr (BYTES Word64)
                       -> Ptr Blake2b
@@ -53,7 +53,7 @@ foreign import ccall unsafe
 
 --
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Blake2b
+              -> BlockCount Blake2b
               -> MT Blake2bMem ()
 
 processBlocks buf blks = do uPtr   <- uLengthCellPointer

--- a/implementation/Blake2b/CPortable.hs
+++ b/implementation/Blake2b/CPortable.hs
@@ -22,13 +22,13 @@ description = "Blake2b Implementation in C exposed by libverse"
 type Prim                    = Blake2b
 type Internals               = Blake2bMem
 type BufferAlignment         = 32
-
+type BufferPtr               = AlignedBlockPtr BufferAlignment Prim
 
 additionalBlocks :: BlockCount Blake2b
 additionalBlocks = blocksOf 1 Proxy
 
 
-processBlocks :: AlignedPointer BufferAlignment
+processBlocks :: BufferPtr
               -> BlockCount Blake2b
               -> MT Blake2bMem ()
 
@@ -59,7 +59,7 @@ processBlocks buf blks =
 --    compression function at the last block using the finalisation
 --    flags.
 --
-processLast :: AlignedPointer BufferAlignment
+processLast :: BufferPtr
             -> BYTES Int
             -> MT Blake2bMem ()
 processLast buf nbytes  = do

--- a/implementation/Blake2b/CPortable.hs
+++ b/implementation/Blake2b/CPortable.hs
@@ -24,12 +24,12 @@ type Internals               = Blake2bMem
 type BufferAlignment         = 32
 
 
-additionalBlocks :: BLOCKS Blake2b
+additionalBlocks :: BlockCount Blake2b
 additionalBlocks = blocksOf 1 Proxy
 
 
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Blake2b
+              -> BlockCount Blake2b
               -> MT Blake2bMem ()
 
 processBlocks buf blks =

--- a/implementation/Blake2s/CHandWritten.hs
+++ b/implementation/Blake2s/CHandWritten.hs
@@ -25,7 +25,7 @@ type Internals               = Blake2sMem
 type BufferAlignment         = 32
 
 
-additionalBlocks :: BLOCKS Prim
+additionalBlocks :: BlockCount Prim
 additionalBlocks = blocksOf 1 Proxy
 
 ------------------------- FFI For Blake2s -------------------------------------
@@ -34,7 +34,7 @@ additionalBlocks = blocksOf 1 Proxy
 foreign import ccall unsafe
   "raaz/hash/blake2/common.h raazHashBlake2sPortableBlockCompress"
   c_blake2s_compress  :: AlignedPointer BufferAlignment
-                      -> BLOCKS Blake2s
+                      -> BlockCount Blake2s
                       -> BYTES Word64
                       -> Ptr Prim
                       -> IO ()
@@ -50,7 +50,7 @@ foreign import ccall unsafe
                    -> IO ()
 --
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Prim
+              -> BlockCount Prim
               -> MT Internals ()
 
 processBlocks buf blks =

--- a/implementation/Blake2s/CHandWritten.hs
+++ b/implementation/Blake2s/CHandWritten.hs
@@ -23,7 +23,7 @@ description = "Hand written Blake2s Implementation using portable C and Haskell 
 type Prim                    = Blake2s
 type Internals               = Blake2sMem
 type BufferAlignment         = 32
-
+type BufferPtr               = AlignedBlockPtr BufferAlignment Prim
 
 additionalBlocks :: BlockCount Prim
 additionalBlocks = blocksOf 1 Proxy
@@ -33,7 +33,7 @@ additionalBlocks = blocksOf 1 Proxy
 
 foreign import ccall unsafe
   "raaz/hash/blake2/common.h raazHashBlake2sPortableBlockCompress"
-  c_blake2s_compress  :: AlignedPointer BufferAlignment
+  c_blake2s_compress  :: BufferPtr
                       -> BlockCount Blake2s
                       -> BYTES Word64
                       -> Ptr Prim
@@ -41,7 +41,7 @@ foreign import ccall unsafe
 
 foreign import ccall unsafe
   "raaz/hash/blake2/common.h raazHashBlake2sPortableLastBlock"
-  c_blake2s_last   :: Pointer
+  c_blake2s_last   :: BlockPtr Prim
                    -> BYTES Int
                    -> BYTES Word64
                    -> Word32
@@ -49,7 +49,7 @@ foreign import ccall unsafe
                    -> Ptr Prim
                    -> IO ()
 --
-processBlocks :: AlignedPointer BufferAlignment
+processBlocks :: BufferPtr
               -> BlockCount Prim
               -> MT Internals ()
 
@@ -59,7 +59,7 @@ processBlocks buf blks =
      updateLength blks
 
 -- | Process the last bytes.
-processLast :: AlignedPointer BufferAlignment
+processLast :: BufferPtr
             -> BYTES Int
             -> MT Internals ()
 processLast buf nbytes  = do

--- a/implementation/ChaCha20/CHandWritten.hs
+++ b/implementation/ChaCha20/CHandWritten.hs
@@ -37,7 +37,7 @@ foreign import ccall unsafe
                    -> BLOCKS ChaCha20                -- number of blocks
                    -> Ptr (Key ChaCha20)             -- key
                    -> Ptr (Nounce ChaCha20)          -- iv
-                   -> Ptr WORD
+                   -> Ptr (WordType ChaCha20)
                    -> IO ()
 
 processBlocks :: AlignedPointer BufferAlignment

--- a/implementation/ChaCha20/CHandWritten.hs
+++ b/implementation/ChaCha20/CHandWritten.hs
@@ -24,7 +24,7 @@ type Internals               = ChaCha20Mem
 type BufferAlignment         = 32
 
 
-additionalBlocks :: BLOCKS ChaCha20
+additionalBlocks :: BlockCount ChaCha20
 additionalBlocks = blocksOf 1 Proxy
 
 
@@ -34,14 +34,14 @@ additionalBlocks = blocksOf 1 Proxy
 foreign import ccall unsafe
   "raaz/cipher/chacha20/cportable.h raazChaCha20Block"
   c_chacha20_block :: AlignedPointer BufferAlignment -- message
-                   -> BLOCKS ChaCha20                -- number of blocks
+                   -> BlockCount ChaCha20                -- number of blocks
                    -> Ptr (Key ChaCha20)             -- key
                    -> Ptr (Nounce ChaCha20)          -- iv
                    -> Ptr (WordType ChaCha20)
                    -> IO ()
 
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Prim
+              -> BlockCount Prim
               -> MT Internals ()
 
 processBlocks buf blks =
@@ -62,11 +62,11 @@ type RandomBufferSize = 16
 
 
 -- | How many blocks of the primitive to generated before re-seeding.
-reseedAfter :: BLOCKS Prim
+reseedAfter :: BlockCount Prim
 reseedAfter = blocksOf (1024 * 1024 * 1024) (Proxy :: Proxy Prim)
 
 randomBlocks :: AlignedPointer BufferAlignment
-             -> BLOCKS Prim
+             -> BlockCount Prim
              -> MT Internals ()
 
 randomBlocks  = processBlocks

--- a/implementation/ChaCha20/CHandWritten.hs
+++ b/implementation/ChaCha20/CHandWritten.hs
@@ -22,7 +22,7 @@ description = "Hand written ChaCha20 Implementation using portable C"
 type Prim                    = ChaCha20
 type Internals               = ChaCha20Mem
 type BufferAlignment         = 32
-
+type BufferPtr               = AlignedBlockPtr BufferAlignment Prim
 
 additionalBlocks :: BlockCount ChaCha20
 additionalBlocks = blocksOf 1 Proxy
@@ -33,14 +33,14 @@ additionalBlocks = blocksOf 1 Proxy
 -- | Chacha20 block transformation.
 foreign import ccall unsafe
   "raaz/cipher/chacha20/cportable.h raazChaCha20Block"
-  c_chacha20_block :: AlignedPointer BufferAlignment -- message
+  c_chacha20_block :: BufferPtr -- message
                    -> BlockCount ChaCha20                -- number of blocks
                    -> Ptr (Key ChaCha20)             -- key
                    -> Ptr (Nounce ChaCha20)          -- iv
                    -> Ptr (WordType ChaCha20)
                    -> IO ()
 
-processBlocks :: AlignedPointer BufferAlignment
+processBlocks :: BufferPtr
               -> BlockCount Prim
               -> MT Internals ()
 
@@ -51,7 +51,7 @@ processBlocks buf blks =
      liftIO     $ c_chacha20_block buf blks keyPtr ivPtr counterPtr
 
 -- | Process the last bytes.
-processLast :: AlignedPointer BufferAlignment
+processLast :: BufferPtr
             -> BYTES Int
             -> MT Internals ()
 processLast buf = processBlocks buf . atLeast
@@ -65,7 +65,7 @@ type RandomBufferSize = 16
 reseedAfter :: BlockCount Prim
 reseedAfter = blocksOf (1024 * 1024 * 1024) (Proxy :: Proxy Prim)
 
-randomBlocks :: AlignedPointer BufferAlignment
+randomBlocks :: BufferPtr
              -> BlockCount Prim
              -> MT Internals ()
 

--- a/implementation/ChaCha20/CPortable.hs
+++ b/implementation/ChaCha20/CPortable.hs
@@ -22,12 +22,12 @@ description = "ChaCha20 Implementation in C exposed by libverse"
 type Prim                    = ChaCha20
 type Internals               = ChaCha20Mem
 type BufferAlignment         = 32
-
+type BufferPtr               = AlignedBlockPtr BufferAlignment Prim
 
 additionalBlocks :: BlockCount ChaCha20
 additionalBlocks = blocksOf 1 Proxy
 
-processBlocks :: AlignedPointer BufferAlignment
+processBlocks :: BufferPtr
               -> BlockCount Prim
               -> MT Internals ()
 
@@ -35,7 +35,7 @@ processBlocks = runBlockProcess verse_chacha20_c_portable
 
 
 -- | Process the last bytes.
-processLast :: AlignedPointer BufferAlignment
+processLast :: BufferPtr
             -> BYTES Int
             -> MT Internals ()
 processLast buf = processBlocks buf . atLeast
@@ -73,7 +73,7 @@ runBlockProcess :: ( Ptr buf ->
                      Ptr c   ->
                      IO ()
                    )
-                -> AlignedPointer BufferAlignment
+                -> BufferPtr
                 -> BlockCount Prim
                 -> MT Internals ()
 runBlockProcess func buf blks =

--- a/implementation/ChaCha20/CPortable.hs
+++ b/implementation/ChaCha20/CPortable.hs
@@ -24,11 +24,11 @@ type Internals               = ChaCha20Mem
 type BufferAlignment         = 32
 
 
-additionalBlocks :: BLOCKS ChaCha20
+additionalBlocks :: BlockCount ChaCha20
 additionalBlocks = blocksOf 1 Proxy
 
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Prim
+              -> BlockCount Prim
               -> MT Internals ()
 
 processBlocks = runBlockProcess verse_chacha20_c_portable
@@ -74,7 +74,7 @@ runBlockProcess :: ( Ptr buf ->
                      IO ()
                    )
                 -> AlignedPointer BufferAlignment
-                -> BLOCKS Prim
+                -> BlockCount Prim
                 -> MT Internals ()
 runBlockProcess func buf blks =
   do keyPtr     <- castPtr <$> keyCellPtr

--- a/implementation/ChaCha20/Random/CPortable.hs
+++ b/implementation/ChaCha20/Random/CPortable.hs
@@ -6,7 +6,7 @@ module ChaCha20.Random.CPortable
 
 import           Raaz.Core
 import qualified ChaCha20.CPortable as Base
-import           ChaCha20.CPortable (Prim, Internals, BufferAlignment, additionalBlocks)
+import           ChaCha20.CPortable (Prim, Internals, BufferAlignment, BufferPtr, additionalBlocks)
 import           Raaz.Verse.Chacha20.C.Portable
 
 name :: String
@@ -28,7 +28,7 @@ reseedAfter = blocksOf (1024 * 1024 * 1024) (Proxy :: Proxy Prim)
 
 
 
-randomBlocks :: AlignedPointer BufferAlignment
+randomBlocks :: BufferPtr
              -> BlockCount Prim
              -> MT Internals ()
 randomBlocks = Base.runBlockProcess verse_chacha20csprg_c_portable

--- a/implementation/ChaCha20/Random/CPortable.hs
+++ b/implementation/ChaCha20/Random/CPortable.hs
@@ -23,12 +23,12 @@ type RandomBufferSize = 16
 
 
 -- | How many blocks of the primitive to generated before re-seeding.
-reseedAfter :: BLOCKS Prim
+reseedAfter :: BlockCount Prim
 reseedAfter = blocksOf (1024 * 1024 * 1024) (Proxy :: Proxy Prim)
 
 
 
 randomBlocks :: AlignedPointer BufferAlignment
-             -> BLOCKS Prim
+             -> BlockCount Prim
              -> MT Internals ()
 randomBlocks = Base.runBlockProcess verse_chacha20csprg_c_portable

--- a/implementation/Poly1305/CPortable.hs
+++ b/implementation/Poly1305/CPortable.hs
@@ -29,12 +29,12 @@ type Internals               = Mem
 type BufferAlignment         = 32
 
 
-additionalBlocks :: BLOCKS Poly1305
+additionalBlocks :: BlockCount Poly1305
 additionalBlocks = blocksOf 1 Proxy
 
 -- | Incrementally process poly1305 blocks.
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Poly1305
+              -> BlockCount Poly1305
               -> MT Internals ()
 processBlocks buf blks = do
   aP <- accumPtr
@@ -45,7 +45,7 @@ processBlocks buf blks = do
 
 -- | Process a message that is exactly a multiple of the blocks.
 blocksMac :: AlignedPointer BufferAlignment
-          -> BLOCKS Poly1305
+          -> BlockCount Poly1305
           -> MT Internals ()
 blocksMac buf blks = runWithRS $ verse_poly1305_c_portable_blockmac bufPtr wBlks
   where bufPtr = castPtr $ forgetAlignment buf
@@ -67,7 +67,7 @@ runWithRS func = do aP <- accumPtr
 -- blocks argument here is the greatest multiple of the block that is
 -- less that the message length.
 partialBlockMac :: AlignedPointer BufferAlignment
-                -> BLOCKS Poly1305
+                -> BlockCount Poly1305
                 -> MT Internals ()
 partialBlockMac buf blks = do
   processBlocks buf blks
@@ -85,8 +85,8 @@ processLast buf nBytes
   | otherwise      = do
       unsafeTransfer pad (forgetAlignment buf)
       partialBlockMac buf blksF
-  where blksC = atLeast nBytes :: BLOCKS Poly1305
-        blksF = atMost  nBytes :: BLOCKS Poly1305
+  where blksC = atLeast nBytes :: BlockCount Poly1305
+        blksF = atMost  nBytes :: BlockCount Poly1305
         pad   = padding nBytes
 
 -- | Poly1305 padding. Call this padding function if and only if the

--- a/implementation/Poly1305/CPortable.hs
+++ b/implementation/Poly1305/CPortable.hs
@@ -4,6 +4,7 @@
 module Poly1305.CPortable
        ( name, description
        , Prim, Internals, BufferAlignment
+       , BufferPtr
        , additionalBlocks
        , processBlocks
        , processLast
@@ -27,13 +28,13 @@ description = "Poly1305 Implementation in C exposed by libverse"
 type Prim                    = Poly1305
 type Internals               = Mem
 type BufferAlignment         = 32
-
+type BufferPtr               = AlignedBlockPtr BufferAlignment Prim
 
 additionalBlocks :: BlockCount Poly1305
 additionalBlocks = blocksOf 1 Proxy
 
 -- | Incrementally process poly1305 blocks.
-processBlocks :: AlignedPointer BufferAlignment
+processBlocks :: BufferPtr
               -> BlockCount Poly1305
               -> MT Internals ()
 processBlocks buf blks = do
@@ -44,7 +45,7 @@ processBlocks buf blks = do
         wBlks  = toEnum $ fromEnum blks
 
 -- | Process a message that is exactly a multiple of the blocks.
-blocksMac :: AlignedPointer BufferAlignment
+blocksMac :: BufferPtr
           -> BlockCount Poly1305
           -> MT Internals ()
 blocksMac buf blks = runWithRS $ verse_poly1305_c_portable_blockmac bufPtr wBlks
@@ -66,7 +67,7 @@ runWithRS func = do aP <- accumPtr
 -- | Process a message that has its last block incomplete. The total
 -- blocks argument here is the greatest multiple of the block that is
 -- less that the message length.
-partialBlockMac :: AlignedPointer BufferAlignment
+partialBlockMac :: BufferPtr
                 -> BlockCount Poly1305
                 -> MT Internals ()
 partialBlockMac buf blks = do
@@ -77,7 +78,7 @@ partialBlockMac buf blks = do
 
 
 -- | Process the last bytes.
-processLast :: AlignedPointer BufferAlignment
+processLast :: BufferPtr
             -> BYTES Int
             -> MT Internals ()
 processLast buf nBytes

--- a/implementation/Sha256/CHandWritten.hs
+++ b/implementation/Sha256/CHandWritten.hs
@@ -29,7 +29,7 @@ type Internals               = Sha256Mem
 type BufferAlignment         = 32
 
 
-additionalBlocks :: BLOCKS Sha256
+additionalBlocks :: BlockCount Sha256
 additionalBlocks = blocksOf 1 Proxy
 
 ------------------------ The foreign function calls  ---------------------
@@ -37,19 +37,19 @@ additionalBlocks = blocksOf 1 Proxy
 foreign import ccall unsafe
   "raaz/hash/sha256/portable.h raazHashSha256PortableCompress"
    c_sha256_compress  :: AlignedPointer BufferAlignment
-                      -> BLOCKS Sha256
+                      -> BlockCount Sha256
                       -> Ptr Sha256
                       -> IO ()
 
 
 compressBlocks :: AlignedPointer BufferAlignment
-               -> BLOCKS Sha256
+               -> BlockCount Sha256
                -> MT Internals ()
 compressBlocks buf blks =  hashCellPointer >>= liftIO . c_sha256_compress buf blks
 
 
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Sha256
+              -> BlockCount Sha256
               -> MT Internals ()
 processBlocks buf blks = compressBlocks buf blks >> updateLength blks
 

--- a/implementation/Sha256/CPortable.hs
+++ b/implementation/Sha256/CPortable.hs
@@ -4,6 +4,7 @@
 module Sha256.CPortable
        ( name, description
        , Prim, Internals, BufferAlignment
+       , BufferPtr
        , additionalBlocks
        , processBlocks
        , processLast
@@ -27,13 +28,13 @@ description = "Sha256 Implementation in C exposed by libverse"
 type Prim                    = Sha256
 type Internals               = Sha256Mem
 type BufferAlignment         = 32
-
+type BufferPtr               = AlignedBlockPtr BufferAlignment Prim
 
 additionalBlocks :: BlockCount Sha256
 additionalBlocks = blocksOf 1 Proxy
 
 -- | The compression algorithm.
-compressBlocks :: AlignedPointer BufferAlignment
+compressBlocks :: BufferPtr
                -> BlockCount Sha256
                -> MT Internals ()
 compressBlocks buf blks = do hPtr <- castPtr <$> hashCellPointer
@@ -42,13 +43,13 @@ compressBlocks buf blks = do hPtr <- castPtr <$> hashCellPointer
                                in liftIO $ verse_sha256_c_portable blkPtr wBlks hPtr
 
 
-processBlocks :: AlignedPointer BufferAlignment
+processBlocks :: BufferPtr
               -> BlockCount Sha256
               -> MT Internals ()
 processBlocks buf blks = compressBlocks buf blks >> updateLength blks
 
 -- | Process the last bytes.
-processLast :: AlignedPointer BufferAlignment
+processLast :: BufferPtr
             -> BYTES Int
             -> MT Internals ()
 processLast = process256Last processBlocks

--- a/implementation/Sha256/CPortable.hs
+++ b/implementation/Sha256/CPortable.hs
@@ -29,12 +29,12 @@ type Internals               = Sha256Mem
 type BufferAlignment         = 32
 
 
-additionalBlocks :: BLOCKS Sha256
+additionalBlocks :: BlockCount Sha256
 additionalBlocks = blocksOf 1 Proxy
 
 -- | The compression algorithm.
 compressBlocks :: AlignedPointer BufferAlignment
-               -> BLOCKS Sha256
+               -> BlockCount Sha256
                -> MT Internals ()
 compressBlocks buf blks = do hPtr <- castPtr <$> hashCellPointer
                              let blkPtr = castPtr $ forgetAlignment buf
@@ -43,7 +43,7 @@ compressBlocks buf blks = do hPtr <- castPtr <$> hashCellPointer
 
 
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Sha256
+              -> BlockCount Sha256
               -> MT Internals ()
 processBlocks buf blks = compressBlocks buf blks >> updateLength blks
 

--- a/implementation/Sha512/CHandWritten.hs
+++ b/implementation/Sha512/CHandWritten.hs
@@ -29,7 +29,7 @@ type Internals               = Sha512Mem
 type BufferAlignment         = 32
 
 
-additionalBlocks :: BLOCKS Sha512
+additionalBlocks :: BlockCount Sha512
 additionalBlocks = blocksOf 1 Proxy
 
 ------------------------ The foreign function calls  ---------------------
@@ -37,20 +37,20 @@ additionalBlocks = blocksOf 1 Proxy
 foreign import ccall unsafe
   "raaz/hash/sha512/portable.h raazHashSha512PortableCompress"
   c_sha512_compress  :: AlignedPointer BufferAlignment
-                     -> BLOCKS Sha512
+                     -> BlockCount Sha512
                      -> Ptr Sha512
                      -> IO ()
 
 
 compressBlocks :: AlignedPointer BufferAlignment
-               -> BLOCKS Sha512
+               -> BlockCount Sha512
                -> MT Internals ()
 compressBlocks buf blks =  hashCell128Pointer
                            >>= liftIO . c_sha512_compress buf blks
 
 
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Sha512
+              -> BlockCount Sha512
               -> MT Internals ()
 processBlocks buf blks = compressBlocks buf blks >> updateLength128 blks
 

--- a/implementation/Sha512/CPortable.hs
+++ b/implementation/Sha512/CPortable.hs
@@ -30,11 +30,11 @@ type Internals               = Sha512Mem
 type BufferAlignment         = 32
 
 
-additionalBlocks :: BLOCKS Sha512
+additionalBlocks :: BlockCount Sha512
 additionalBlocks = blocksOf 1 Proxy
 
 compressBlocks :: AlignedPointer BufferAlignment
-               -> BLOCKS Sha512
+               -> BlockCount Sha512
                -> MT Internals ()
 compressBlocks buf blks = do hPtr <- castPtr <$> hashCell128Pointer
                              let blkPtr = castPtr $ forgetAlignment buf
@@ -42,7 +42,7 @@ compressBlocks buf blks = do hPtr <- castPtr <$> hashCell128Pointer
                                in liftIO $ verse_sha512_c_portable blkPtr wBlks hPtr
 
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Sha512
+              -> BlockCount Sha512
               -> MT Internals ()
 processBlocks buf blks = compressBlocks buf blks >> updateLength128 blks
 

--- a/indef/Implementation.hsig
+++ b/indef/Implementation.hsig
@@ -49,12 +49,12 @@ type BufferAlignment = 32
 #endif
 
 -- | The additional space required in the buffer for processing the data.
-additionalBlocks :: BLOCKS Prim
+additionalBlocks :: BlockCount Prim
 
 -- | The function that process bytes in multiples of the block size of
 -- the primitive.
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Prim
+              -> BlockCount Prim
               -> MT Internals ()
 
 -- | Process the last bytes of the stream.

--- a/indef/Implementation.hsig
+++ b/indef/Implementation.hsig
@@ -48,16 +48,20 @@ instance KnownNat BufferAlignment
 type BufferAlignment = 32
 #endif
 
+-- | The pointer type associated with the buffer used by the
+-- implementation.
+type BufferPtr = AlignedBlockPtr BufferAlignment Prim
+
 -- | The additional space required in the buffer for processing the data.
 additionalBlocks :: BlockCount Prim
 
 -- | The function that process bytes in multiples of the block size of
 -- the primitive.
-processBlocks :: AlignedPointer BufferAlignment
+processBlocks :: BufferPtr
               -> BlockCount Prim
               -> MT Internals ()
 
 -- | Process the last bytes of the stream.
-processLast :: AlignedPointer BufferAlignment
+processLast :: BufferPtr
             -> BYTES Int
             -> MT Internals ()

--- a/indef/Utils.hs
+++ b/indef/Utils.hs
@@ -31,7 +31,7 @@ processByteSource :: ByteSource src => src -> MT Internals ()
 processByteSource src
   = allocBufferFor blks $
     \ ptr -> processChunks (processBlocks ptr blks) (processLast ptr) src blks (forgetAlignment ptr)
-  where blks       = atLeast l1Cache :: BLOCKS Prim
+  where blks       = atLeast l1Cache :: BlockCount Prim
 
 transform :: ByteString -> MT Internals ByteString
 transform bs

--- a/indef/Utils.hs
+++ b/indef/Utils.hs
@@ -11,7 +11,6 @@ module Utils
 import Control.Monad.IO.Class          (liftIO)
 import Data.ByteString          as B
 import Data.ByteString.Internal as IB
-import Foreign.Ptr                     (castPtr)
 import GHC.TypeLits
 
 import Raaz.Core
@@ -30,7 +29,8 @@ processBuffer buf = processBlocks (getBufferPointer buf) $ bufferSize $ pure buf
 processByteSource :: ByteSource src => src -> MT Internals ()
 processByteSource src
   = allocBufferFor blks $
-    \ ptr -> processChunks (processBlocks ptr blks) (processLast ptr) src blks (forgetAlignment ptr)
+    \ ptr -> processChunks (processBlocks ptr blks) (processLast ptr) src blks
+             $ forgetAlignment ptr
   where blks       = atLeast l1Cache :: BlockCount Prim
 
 transform :: ByteString -> MT Internals ByteString
@@ -41,7 +41,7 @@ transform bs
       in do liftIO $ unsafeCopyToPointer bs bufPtr -- Copy the input to buffer.
             processLast buf strSz
             liftIO $ IB.create sbytes $
-              \ ptr -> Raaz.Core.memcpy (destination (castPtr ptr)) (source bufPtr) strSz
+              \ ptr -> Raaz.Core.memcpy (destination ptr) (source bufPtr) strSz
   where strSz           = Raaz.Core.length bs
         BYTES sbytes    = strSz
         --

--- a/indef/buffer/Buffer.hs
+++ b/indef/buffer/Buffer.hs
@@ -36,14 +36,14 @@ getBufferPointer = nextAlignedPtr . unBuffer
 {-# INLINE bufferSize #-}
 -- | The size of data (measured in blocks) that can be safely
 -- processed inside this buffer.
-bufferSize :: KnownNat n => Proxy (Buffer n) -> BLOCKS Prim
+bufferSize :: KnownNat n => Proxy (Buffer n) -> BlockCount Prim
 bufferSize = flip blocksOf Proxy . fromIntegral . natVal . nProxy
   where nProxy :: Proxy (Buffer n) -> Proxy n
         nProxy  _ = Proxy
 
 -- | Internal function used by allocation.  WARNING: Not to be exposed
 -- else can be confusing with `bufferSize`.
-actualBufferSize :: KnownNat n => Proxy (Buffer n) -> BLOCKS Prim
+actualBufferSize :: KnownNat n => Proxy (Buffer n) -> BlockCount Prim
 actualBufferSize bproxy = bufferSize bproxy <> additionalBlocks
 
 instance KnownNat n => Memory (Buffer n) where
@@ -57,7 +57,7 @@ instance KnownNat n => Memory (Buffer n) where
   unsafeToPointer = unBuffer
 
 allocBufferFor :: MonadIOCont m
-               => BLOCKS Prim
+               => BlockCount Prim
                -> (BufferPtr  -> m a) -> m a
 
 allocBufferFor blks = allocaAligned totalSize

--- a/indef/buffer/Buffer.hs
+++ b/indef/buffer/Buffer.hs
@@ -15,10 +15,6 @@ import GHC.TypeLits
 import Raaz.Core
 import Implementation
 
--- | The pointer type associated with the buffer used by the
--- implementation.
-type BufferPtr = AlignedPointer BufferAlignment
-
 -- | A memory buffer than can handle up to @n@ blocks of data. This
 -- happens when you need to do some transformation on internal data
 -- using a primitive. An example is using a stream cipher for
@@ -31,7 +27,7 @@ newtype Buffer (n :: Nat) = Buffer { unBuffer :: Pointer }
 
 -- | Get the underlying pointer for the buffer.
 getBufferPointer :: Buffer n -> BufferPtr
-getBufferPointer = nextAlignedPtr . unBuffer
+getBufferPointer = castAlignedPtr . nextAlignedPtr . unBuffer
 
 {-# INLINE bufferSize #-}
 -- | The size of data (measured in blocks) that can be safely
@@ -55,6 +51,7 @@ instance KnownNat n => Memory (Buffer n) where
           sz              = atLeastAligned (actualBufferSize $ bufferProxy allocThisBuffer) algn
 
   unsafeToPointer = unBuffer
+
 
 allocBufferFor :: MonadIOCont m
                => BlockCount Prim

--- a/indef/buffer/Implementation.hsig
+++ b/indef/buffer/Implementation.hsig
@@ -3,4 +3,7 @@
 -- implementations involve other details like the alignment
 -- restriction on the input buffer and all that. We package all this
 -- in the following signature.
-signature Implementation( Prim, Internals, BufferAlignment, additionalBlocks ) where
+signature Implementation( Prim, Internals
+                        , BufferAlignment
+                        , BufferPtr
+                        , additionalBlocks ) where

--- a/indef/chacha20/Implementation.hsig
+++ b/indef/chacha20/Implementation.hsig
@@ -46,8 +46,8 @@ type Prim = ChaCha20
 data Internals
 instance Memory Internals
 
-instance Initialisable Internals (BLOCKS ChaCha20)
-instance Extractable   Internals (BLOCKS ChaCha20)
+instance Initialisable Internals (BlockCount ChaCha20)
+instance Extractable   Internals (BlockCount ChaCha20)
 
 -- | The function that sets the internal state for the xchacha
 -- variant.

--- a/indef/chacha20/XChaCha20/Implementation.hs
+++ b/indef/chacha20/XChaCha20/Implementation.hs
@@ -43,27 +43,27 @@ instance Initialisable Internals (Nounce XChaCha20) where
                             in liftIO $ Base.copyKey dest src
                           withReaderT chacha20Internals $ Base.xchacha20Setup xnounce
 
-instance Initialisable Internals (BLOCKS XChaCha20) where
+instance Initialisable Internals (BlockCount XChaCha20) where
   initialise = withReaderT chacha20Internals . initialise . coerce
-    where coerce :: BLOCKS XChaCha20 -> BLOCKS ChaCha20
+    where coerce :: BlockCount XChaCha20 -> BlockCount ChaCha20
           coerce = toEnum . fromEnum
 
-instance Extractable Internals (BLOCKS XChaCha20) where
+instance Extractable Internals (BlockCount XChaCha20) where
   extract = coerce <$> withReaderT chacha20Internals extract
-    where coerce :: BLOCKS ChaCha20 -> BLOCKS XChaCha20
+    where coerce :: BlockCount ChaCha20 -> BlockCount XChaCha20
           coerce = toEnum . fromEnum
 
-additionalBlocks :: BLOCKS XChaCha20
+additionalBlocks :: BlockCount XChaCha20
 additionalBlocks = coerce Base.additionalBlocks
-    where coerce :: BLOCKS Base.Prim -> BLOCKS XChaCha20
+    where coerce :: BlockCount Base.Prim -> BlockCount XChaCha20
           coerce = toEnum . fromEnum
 
 
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Prim
+              -> BlockCount Prim
               -> MT Internals ()
 processBlocks buf = withReaderT chacha20Internals . Base.processBlocks buf . coerce
-  where coerce :: BLOCKS XChaCha20 -> BLOCKS Base.Prim
+  where coerce :: BlockCount XChaCha20 -> BlockCount Base.Prim
         coerce = toEnum . fromEnum
 
 -- | Process the last bytes.

--- a/indef/chacha20/XChaCha20/Implementation.hs
+++ b/indef/chacha20/XChaCha20/Implementation.hs
@@ -27,6 +27,7 @@ data Internals               = XChaCha20Mem
   }
 
 type BufferAlignment         = Base.BufferAlignment
+type BufferPtr               = AlignedBlockPtr BufferAlignment Prim
 
 instance Memory Internals where
   memoryAlloc     = XChaCha20Mem <$> memoryAlloc <*> memoryAlloc
@@ -59,15 +60,15 @@ additionalBlocks = coerce Base.additionalBlocks
           coerce = toEnum . fromEnum
 
 
-processBlocks :: AlignedPointer BufferAlignment
+processBlocks :: BufferPtr
               -> BlockCount Prim
               -> MT Internals ()
-processBlocks buf = withReaderT chacha20Internals . Base.processBlocks buf . coerce
+processBlocks buf = withReaderT chacha20Internals . Base.processBlocks (castAlignedPtr buf) . coerce
   where coerce :: BlockCount XChaCha20 -> BlockCount Base.Prim
         coerce = toEnum . fromEnum
 
 -- | Process the last bytes.
-processLast :: AlignedPointer BufferAlignment
+processLast :: BufferPtr
             -> BYTES Int
             -> MT Internals ()
-processLast buf = withReaderT chacha20Internals . Base.processLast buf
+processLast buf = withReaderT chacha20Internals . Base.processLast (castAlignedPtr buf)

--- a/indef/keyed/hash/Mac/Implementation.hs
+++ b/indef/keyed/hash/Mac/Implementation.hs
@@ -48,14 +48,14 @@ description = "Implementation of a MAC based on simple keyed hashing that makes 
 
 type BufferAlignment = Base.BufferAlignment
 
-toKeyedBlocks :: BLOCKS Base.Prim -> BLOCKS Prim
+toKeyedBlocks :: BlockCount Base.Prim -> BlockCount Prim
 toKeyedBlocks = toEnum . fromEnum
 
-fromKeyedBlocks :: BLOCKS Prim -> BLOCKS Base.Prim
+fromKeyedBlocks :: BlockCount Prim -> BlockCount Base.Prim
 fromKeyedBlocks = toEnum . fromEnum
 
 -- | The additional space required in the buffer for processing the data.
-additionalBlocks :: BLOCKS Prim
+additionalBlocks :: BlockCount Prim
 additionalBlocks = toKeyedBlocks Base.additionalBlocks
 
 trim ::  Key (Keyed Base.Prim) -> BS.ByteString
@@ -130,7 +130,7 @@ instance Extractable Internals Prim where
 -- | The function that process bytes in multiples of the block size of
 -- the primitive.
 processBlocks :: AlignedPointer BufferAlignment
-              -> BLOCKS Prim
+              -> BlockCount Prim
               -> MT Internals ()
 processBlocks aptr blks = do
   start <- withReaderT atStart extract

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -267,7 +267,7 @@ library core
 library libverse
   import: defaults
   build-depends: core
-  hs-source-dirs: libverse
+  hs-source-dirs: verse
   exposed-modules: Raaz.Verse.Chacha20.C.Portable
                  , Raaz.Verse.Sha512.C.Portable
                  , Raaz.Verse.Sha256.C.Portable

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -192,7 +192,7 @@ common defaults
   default-language: Haskell2010
   ghc-options: -Wall
   default-extensions: NoImplicitPrelude
-  build-depends: base                    >= 4.11 &&  < 4.14
+  build-depends: base                    >= 4.11 &&  < 4.15
                , bytestring              >= 0.10 &&  < 0.11
                , deepseq                 >= 1.4  &&  < 1.5
                , vector                  >= 0.12 &&  < 0.13

--- a/raaz/Raaz/V1/Encrypt.hs
+++ b/raaz/Raaz/V1/Encrypt.hs
@@ -31,7 +31,7 @@ encrypt = XChaCha20.encrypt
 -- | Encryption starting at a given block offset.
 encryptAt :: Key Cipher    -- ^
           -> Nounce Cipher
-          -> BLOCKS Cipher
+          -> BlockCount Cipher
           -> ByteString
           -> ByteString
 encryptAt = XChaCha20.encryptAt
@@ -39,7 +39,7 @@ encryptAt = XChaCha20.encryptAt
 -- | Same as decryption but starting at a given offset.
 decryptAt :: Key Cipher
           -> Nounce Cipher
-          -> BLOCKS Cipher
+          -> BlockCount Cipher
           -> ByteString
           -> ByteString
 decryptAt = XChaCha20.decryptAt

--- a/tests/core/Tests/Core/Imports.hs
+++ b/tests/core/Tests/Core/Imports.hs
@@ -12,8 +12,8 @@ import Test.QuickCheck.Monadic as E
 import Raaz.Core               as E hiding ((===), Result, (.&.))
 
 import Raaz.Primitive.Blake2.Internal   as E
-import Raaz.Primitive.ChaCha20.Internal as E hiding ( WORD, Key )
-import Raaz.Primitive.Poly1305.Internal as E hiding ( WORD, Key )
+import Raaz.Primitive.ChaCha20.Internal as E hiding ( Key )
+import Raaz.Primitive.Poly1305.Internal as E hiding ( Key )
 import Raaz.Primitive.Sha2.Internal     as E
 
 

--- a/tests/core/Tests/Core/Instances.hs
+++ b/tests/core/Tests/Core/Instances.hs
@@ -61,7 +61,7 @@ instance Arbitrary (Key ChaCha20) where
 instance Arbitrary (Nounce ChaCha20) where
   arbitrary = genEncodable
 
-instance Arbitrary (BLOCKS ChaCha20) where
+instance Arbitrary (BlockCount ChaCha20) where
   arbitrary = toEnum <$> arbitrary
 
 ------------------ For XChaCha20 types -------------------------
@@ -72,7 +72,7 @@ instance Arbitrary (Key XChaCha20) where
 instance Arbitrary (Nounce XChaCha20) where
   arbitrary = genEncodable
 
-instance Arbitrary (BLOCKS XChaCha20) where
+instance Arbitrary (BlockCount XChaCha20) where
   arbitrary = toEnum <$> arbitrary
 
 ------------------ Arbitrary instances for Poly1305 -------------

--- a/verse/Raaz/Verse/Blake2b/C/Portable.hs
+++ b/verse/Raaz/Verse/Blake2b/C/Portable.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE 
+                DataKinds,
+                ForeignFunctionInterface #-}
+module Raaz.Verse.Blake2b.C.Portable where
+import Raaz.Core
+import Foreign.Ptr
+foreign import ccall unsafe
+    verse_blake2b_c_portable_iter :: Ptr (Tuple 16 Word64)
+                                  -> Word64
+                                  -> Ptr Word64
+                                  -> Ptr Word64
+                                  -> Ptr (Tuple 8 Word64)
+                                  -> IO ()
+foreign import ccall unsafe
+    verse_blake2b_c_portable_last :: Ptr (Tuple 16 Word64)
+                                  -> Word64
+                                  -> Word64
+                                  -> Word64
+                                  -> Word64
+                                  -> Word64
+                                  -> Ptr (Tuple 8 Word64)
+                                  -> IO ()

--- a/verse/Raaz/Verse/Blake2b/C/Portable.hs
+++ b/verse/Raaz/Verse/Blake2b/C/Portable.hs
@@ -3,7 +3,6 @@
                 ForeignFunctionInterface #-}
 module Raaz.Verse.Blake2b.C.Portable where
 import Raaz.Core
-import Foreign.Ptr
 foreign import ccall unsafe
     verse_blake2b_c_portable_iter :: Ptr (Tuple 16 Word64)
                                   -> Word64

--- a/verse/Raaz/Verse/Blake2s/C/Portable.hs
+++ b/verse/Raaz/Verse/Blake2s/C/Portable.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE 
+                DataKinds,
+                ForeignFunctionInterface #-}
+module Raaz.Verse.Blake2s.C.Portable where
+import Raaz.Core
+import Foreign.Ptr
+foreign import ccall unsafe
+    verse_blake2s_c_portable_iter :: Ptr (Tuple 16 Word32)
+                                  -> Word64
+                                  -> Ptr Word32
+                                  -> Ptr Word32
+                                  -> Ptr (Tuple 8 Word32)
+                                  -> IO ()
+foreign import ccall unsafe
+    verse_blake2s_c_portable_last :: Ptr (Tuple 16 Word32)
+                                  -> Word32
+                                  -> Word32
+                                  -> Word32
+                                  -> Word32
+                                  -> Word32
+                                  -> Ptr (Tuple 8 Word32)
+                                  -> IO ()

--- a/verse/Raaz/Verse/Blake2s/C/Portable.hs
+++ b/verse/Raaz/Verse/Blake2s/C/Portable.hs
@@ -3,7 +3,6 @@
                 ForeignFunctionInterface #-}
 module Raaz.Verse.Blake2s.C.Portable where
 import Raaz.Core
-import Foreign.Ptr
 foreign import ccall unsafe
     verse_blake2s_c_portable_iter :: Ptr (Tuple 16 Word32)
                                   -> Word64

--- a/verse/Raaz/Verse/Chacha20/C/Portable.hs
+++ b/verse/Raaz/Verse/Chacha20/C/Portable.hs
@@ -3,7 +3,6 @@
                 ForeignFunctionInterface #-}
 module Raaz.Verse.Chacha20.C.Portable where
 import Raaz.Core
-import Foreign.Ptr
 foreign import ccall unsafe
     verse_chacha20_c_portable :: Ptr (Tuple 16 Word32)
                               -> Word64

--- a/verse/Raaz/Verse/Chacha20/C/Portable.hs
+++ b/verse/Raaz/Verse/Chacha20/C/Portable.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE 
+                DataKinds,
+                ForeignFunctionInterface #-}
+module Raaz.Verse.Chacha20.C.Portable where
+import Raaz.Core
+import Foreign.Ptr
+foreign import ccall unsafe
+    verse_chacha20_c_portable :: Ptr (Tuple 16 Word32)
+                              -> Word64
+                              -> Ptr (Tuple 8 Word32)
+                              -> Ptr (Tuple 3 Word32)
+                              -> Ptr Word32
+                              -> IO ()
+foreign import ccall unsafe
+    verse_chacha20csprg_c_portable :: Ptr (Tuple 16 Word32)
+                                   -> Word64
+                                   -> Ptr (Tuple 8 Word32)
+                                   -> Ptr (Tuple 3 Word32)
+                                   -> Ptr Word32
+                                   -> IO ()
+foreign import ccall unsafe
+    verse_hchacha20_c_portable :: Ptr (Tuple 8 Word32)
+                               -> Word32
+                               -> Word32
+                               -> Word32
+                               -> Word32
+                               -> IO ()

--- a/verse/Raaz/Verse/Poly1305/C/Portable.hs
+++ b/verse/Raaz/Verse/Poly1305/C/Portable.hs
@@ -3,7 +3,6 @@
                 ForeignFunctionInterface #-}
 module Raaz.Verse.Poly1305.C.Portable where
 import Raaz.Core
-import Foreign.Ptr
 foreign import ccall unsafe
     verse_poly1305_c_portable_incremental :: Ptr (Tuple 2 Word64)
                                           -> Word64

--- a/verse/Raaz/Verse/Poly1305/C/Portable.hs
+++ b/verse/Raaz/Verse/Poly1305/C/Portable.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE 
+                DataKinds,
+                ForeignFunctionInterface #-}
+module Raaz.Verse.Poly1305.C.Portable where
+import Raaz.Core
+import Foreign.Ptr
+foreign import ccall unsafe
+    verse_poly1305_c_portable_incremental :: Ptr (Tuple 2 Word64)
+                                          -> Word64
+                                          -> Ptr (Tuple 3 Word64)
+                                          -> Ptr (Tuple 2 Word64)
+                                          -> IO ()
+foreign import ccall unsafe
+    verse_poly1305_c_portable_blockmac :: Ptr (Tuple 2 Word64)
+                                       -> Word64
+                                       -> Ptr (Tuple 3 Word64)
+                                       -> Ptr (Tuple 2 Word64)
+                                       -> Ptr (Tuple 2 Word64)
+                                       -> IO ()
+foreign import ccall unsafe
+    verse_poly1305_c_portable_partialmac :: Ptr (Tuple 2 Word64)
+                                         -> Ptr (Tuple 3 Word64)
+                                         -> Ptr (Tuple 2 Word64)
+                                         -> Ptr (Tuple 2 Word64)
+                                         -> IO ()
+foreign import ccall unsafe
+    verse_poly1305_c_portable_clamp :: Ptr (Tuple 2 Word64)
+                                    -> Word64
+                                    -> IO ()

--- a/verse/Raaz/Verse/Sha256/C/Portable.hs
+++ b/verse/Raaz/Verse/Sha256/C/Portable.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE 
+                DataKinds,
+                ForeignFunctionInterface #-}
+module Raaz.Verse.Sha256.C.Portable where
+import Raaz.Core
+import Foreign.Ptr
+foreign import ccall unsafe
+    verse_sha256_c_portable :: Ptr (Tuple 16 Word32)
+                            -> Word64
+                            -> Ptr (Tuple 8 Word32)
+                            -> IO ()

--- a/verse/Raaz/Verse/Sha256/C/Portable.hs
+++ b/verse/Raaz/Verse/Sha256/C/Portable.hs
@@ -3,7 +3,6 @@
                 ForeignFunctionInterface #-}
 module Raaz.Verse.Sha256.C.Portable where
 import Raaz.Core
-import Foreign.Ptr
 foreign import ccall unsafe
     verse_sha256_c_portable :: Ptr (Tuple 16 Word32)
                             -> Word64

--- a/verse/Raaz/Verse/Sha512/C/Portable.hs
+++ b/verse/Raaz/Verse/Sha512/C/Portable.hs
@@ -3,7 +3,6 @@
                 ForeignFunctionInterface #-}
 module Raaz.Verse.Sha512.C.Portable where
 import Raaz.Core
-import Foreign.Ptr
 foreign import ccall unsafe
     verse_sha512_c_portable :: Ptr (Tuple 16 Word64)
                             -> Word64

--- a/verse/Raaz/Verse/Sha512/C/Portable.hs
+++ b/verse/Raaz/Verse/Sha512/C/Portable.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE 
+                DataKinds,
+                ForeignFunctionInterface #-}
+module Raaz.Verse.Sha512.C.Portable where
+import Raaz.Core
+import Foreign.Ptr
+foreign import ccall unsafe
+    verse_sha512_c_portable :: Ptr (Tuple 16 Word64)
+                            -> Word64
+                            -> Ptr (Tuple 8 Word64)
+                            -> IO ()


### PR DESCRIPTION
Primitives were captured by their blocksize (which is given by an associated type). We recast this
into two parts, an associated type  WordType (all primitives have a basic word on which it is defined) and an associated type WordsPerBlock. 