### PR TITLE
Better interface for authenticated encryption

### DIFF
--- a/api/random/PRGenerator.hs
+++ b/api/random/PRGenerator.hs
@@ -18,8 +18,7 @@
 module PRGenerator
        ( -- * Pseudo-random generator
          -- $internals$
-         RandomState, reseed, fillRandomBytes,
-         withRandomState, withSecureRandomState
+         RandomState, reseed, fillRandomBytes
          -- ** Information about the cryptographic generator.
        , entropySource, csprgName, csprgDescription
        ) where
@@ -113,16 +112,6 @@ instance Memory RandomState where
 instance WriteAccessible RandomState where
   writeAccess          = writeAccess . cxtInternals . randomCxt
   afterWriteAdjustment = afterWriteAdjustment . cxtInternals . randomCxt
-
--- | Execute an action that takes the CSPRG state.
-withRandomState :: (RandomState -> IO a) -> IO a
-withRandomState action = withMemory (\ rstate -> reseed rstate >> action rstate)
-
--- | Execute an action that takes a memory element and random state
--- such that all the memory allocated for both of them is locked.
-withSecureRandomState :: Memory mem => (mem -> RandomState -> IO a) -> IO a
-withSecureRandomState action = withSecureMemory (uncurry actionP)
-  where actionP mem rstate = reseed rstate >> action mem rstate
 
 -------------------------------- The PRG operations ---------------------------------------------
 

--- a/monocypher/tests/Monocypher/ChaCha20Spec.hs
+++ b/monocypher/tests/Monocypher/ChaCha20Spec.hs
@@ -188,24 +188,24 @@ spec = do
       \ k n x -> monocypher_xchacha20_encrypt k n x `shouldBe` XChaCha20.encrypt k n x
 
     prop "raaz lock and monocypher unlock are inverses" $
-      \ k n (x :: ByteString) -> monocypher_unlock k n (XP.lock k n x) `shouldBe` Just x
+      \ k n (x :: ByteString) -> monocypher_unlock k n (XP.unsafeLock k n x) `shouldBe` Just x
 
     prop "raaz lockWith vs monocypher unlockAead are inverses" $
       \ k n (aad :: ByteString) (x :: ByteString)
-      -> monocypher_unlock_aead aad k n (XP.lockWith aad k n x) `shouldBe` Just x
+      -> monocypher_unlock_aead aad k n (XP.unsafeLockWith aad k n x) `shouldBe` Just x
 
   describe "raaz - lock/unlock are inverses" $ do
 
     prop "chacha20poly1305 " $
-      \ k n (x :: ByteString) -> CP.unlock k n (CP.lock k n x) `shouldBe` Just x
+      \ k n (x :: ByteString) -> CP.unlock k (CP.unsafeLock k n x) `shouldBe` Just x
 
     prop "xchacha20poly1305" $
-      \ k n (x :: ByteString) -> XP.unlock k n (XP.lock k n x) `shouldBe` Just x
+      \ k n (x :: ByteString) -> XP.unlock k (XP.unsafeLock k n x) `shouldBe` Just x
 
     prop "chacha20poly1305-aead" $
       \ k n (aad :: ByteString) (x :: ByteString)
-      -> CP.unlockWith aad k n (CP.lockWith aad k n x) `shouldBe` Just x
+      -> CP.unlockWith aad k (CP.unsafeLockWith aad k n x) `shouldBe` Just x
 
     prop "xchacha20poly1305-aead" $
       \ k n (aad :: ByteString) (x :: ByteString)
-      -> XP.unlockWith aad  k n (XP.lockWith aad k n x) `shouldBe` Just x
+      -> XP.unlockWith aad  k (XP.unsafeLockWith aad k n x) `shouldBe` Just x

--- a/raaz.cabal
+++ b/raaz.cabal
@@ -554,8 +554,10 @@ library
         , mac-indef (Mac.Implementation as Blake2s.Mac.Implementation)
             requires (Implementation as Blake2s.Implementation)
 
-        , auth-api (Interface as Raaz.Auth.Blake2b) requires (Implementation as Blake2b.Mac.Implementation)
-        , auth-api (Interface as Raaz.Auth.Blake2s) requires (Implementation as Blake2s.Mac.Implementation)
+        , auth-api (Interface as Raaz.Auth.Blake2b)
+             requires (Implementation as Blake2b.Mac.Implementation)
+        , auth-api (Interface as Raaz.Auth.Blake2s)
+             requires (Implementation as Blake2s.Mac.Implementation)
 
 
         --

--- a/raaz/Raaz/V1/AuthEncrypt.hs
+++ b/raaz/Raaz/V1/AuthEncrypt.hs
@@ -9,6 +9,9 @@ module Raaz.V1.AuthEncrypt
   ( lock, unlock
   , lockWith, unlockWith
   , AEAD, Locked
+    -- * Unsafe interfaces
+    -- $unsafeinterface$
+  , unsafeLock, unsafeLockWith
   , unsafeAEAD
   , unsafeToCipherText
   , unsafeToAuthTag
@@ -19,27 +22,56 @@ import           Data.ByteString
 import           Raaz.Core
 import qualified Raaz.AuthEncrypt.XChaCha20Poly1305 as AE
 import           Raaz.AuthEncrypt.XChaCha20Poly1305 (AEAD, Locked, Cipher)
+import           Raaz.Random                        (random, withRandomState)
 
--- | This function takes the plain text and the additional data, and
--- constructs the AEAD token. A peer who has the right @(key, nounce)@
--- pair and the `aad` can recover the unencrypted object using the
+-- | This function locks a plain text message together with and
+-- additional authenticated data to produce an constructs the AEAD
+-- token. A peer who has the right @key@ and the additional
+-- authenticated data can recover the unencrypted object using the
 -- `unlockWith` function.
+--
+-- Unlike `unsafeLockWith`, this function does not require a nounce as
+-- internally a random nounce is generated and used each time. As a
+-- result we do not put any restriction on the key used ; it is safe
+-- to use the same key multiple times.
+
 lockWith :: (Encodable plain, Encodable aad)
-        => aad              -- ^ the authenticated additional data.
-        -> Key Cipher       -- ^ The key
-        -> Nounce Cipher    -- ^ The nounce
-        -> plain            -- ^ the unencrypted object
-        -> AEAD plain aad
-lockWith = AE.lockWith
+         => aad              -- ^ the authenticated additional data.
+         -> Key Cipher       -- ^ The key
+         -> plain            -- ^ the unencrypted object
+         -> IO (AEAD plain aad)
+lockWith aad key plain =
+  withRandomState $ \ rstate -> do
+  nounce <- random rstate
+  return $ unsafeLockWith aad key nounce plain
+
+-- | Similar to `lockWith` but an explicit nounce is taken as
+-- input. Reusing the key-nounce pair will compromise the security and
+-- hence using this function is unsafe. The user needs to ensure the
+-- freshness of the key, nounce pair through some other means.
+--
+-- Some protocols have a predefined way to pick nounces and this is
+-- the reason, we provide such an interface. If that is not a concern,
+-- we recommend the use of `lockWith` instead.
+unsafeLockWith :: (Encodable plain, Encodable aad)
+               => aad
+               -> Key Cipher
+               -> Nounce Cipher
+               -> plain
+               -> AEAD plain aad
+unsafeLockWith = AE.unsafeLockWith
 
 -- | Unlock an encrypted authenticated version of the data given the
 -- additional data, key, and nounce. An attempt to unlock the element
 -- can result in `Nothing` if either of the following is true.
 --
--- 1. The key, nounce pair used to encrypt the data is different
+-- 1. The key/nounce used to encrypt the data is different
+--
 -- 2. The Authenticated additional data (@aad@) is incorrect
+--
 -- 3. The AEAD is of the wrong type and hence the fromByteString failed
--- 4. The AEAD value has been tampered with by the adversery
+--
+-- 4. The AEAD value has been tampered with by the adversary
 --
 -- The interface provided does not indicate which of the above
 -- failures had happened. This is a deliberate design as revealing the
@@ -48,27 +80,44 @@ lockWith = AE.lockWith
 unlockWith :: (Encodable plain, Encodable aad)
            => aad              -- ^ the authenticated additional data.
            -> Key Cipher       -- ^ The key for the stream cipher
-           -> Nounce Cipher    -- ^ The nounce used by the stream cipher.
            -> AEAD plain aad   -- ^ The encrypted authenticated version of the data.
            -> Maybe plain
 unlockWith = AE.unlockWith
 
 
 -- | Generate a locked version of an unencrypted object. You will need
--- the exact same key and nounce to `unlock` the object.
+-- the exact same key to `unlock` the object. Unlike `unsafelock`,
+-- this function does not require a nounce as internally a random
+-- nounce is generated and used each time. Because of this, it is safe
+-- to use the same key multiple times.
 lock :: Encodable plain
      => Key Cipher        -- ^ The key
-     -> Nounce Cipher     -- ^ The nounce
      -> plain             -- ^ The object to be locked.
-     -> Locked plain
-lock = AE.lock
+     -> IO (Locked plain)
+lock = lockWith ()
+
+
+
+-- | Locks a given message but needs an explicit nounce. Reusing the
+-- key-nounce pair will compromise the security and hence using this
+-- function is unsafe. The user needs to ensure the freshness of the
+-- key, nounce pair through some other means.
+--
+-- Some protocols have a predefined way to pick nounces and this is
+-- the reason we provide such an interface. If that is not a concern,
+-- we recommend the use of `lock` instead.
+unsafeLock :: Encodable plain
+           => Key Cipher        -- ^ The key
+           -> Nounce Cipher     -- ^ The nounce
+           -> plain             -- ^ The object to be locked.
+           -> Locked plain
+unsafeLock = AE.unsafeLock
 
 
 -- | Unlock the locked version of an object. You will need the exact
--- same key and nounce that was used to lock the object.
+-- same key that was used to lock the object.
 unlock :: Encodable plain
        => Key Cipher      -- ^ The key
-       -> Nounce Cipher   -- ^ The nounce
        -> Locked plain    -- ^ Locked object that needs unlocking
        -> Maybe plain
 unlock = AE.unlock
@@ -86,7 +135,8 @@ unsafeToAuthTag = AE.unsafeToAuthTag
 
 -- | Construct an AEAD packet out of the authentication token and the
 -- cipher text.
-unsafeAEAD :: ByteString
+unsafeAEAD :: Nounce Cipher
+           -> ByteString
            -> AE.Auth
            -> AEAD plain aad
 unsafeAEAD = AE.unsafeAEAD


### PR DESCRIPTION
The default lock and lockWith functions now use a randomly generated nouce for each call. This is both simpler (one argument less) and safer (reuse of key nounce prevented) interface. 